### PR TITLE
Add yarn install and foreman install into setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ The app is currently a Rails 7 skeleton with support for Tailwind CSS.
 
 ### Getting started
 
-```
-$ bundle
-$ yarn install
-$ bin/dev
-```
+Run `bin/setup`
+
+### Development
+
+Run `bin/dev`
+
+### Testing
+
+Run `rails test` to run unit/integration tests
+Run `rails test:system` to run system/browser tests

--- a/bin/setup
+++ b/bin/setup
@@ -21,6 +21,11 @@ FileUtils.chdir APP_ROOT do
   # unless File.exist?('config/database.yml')
   #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
+  # Install JavaScript dependencies
+  system! 'yarn install'
+
+  puts "\n== Install foreman which is used by bin/dev script =="
+  system! 'gem install foreman'
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'


### PR DESCRIPTION
`bin/dev` requires Foreman installed (outside of Gemfile).

We can install packages with  `yarn install` in `bin/setup` too.

The README then just documents the simple commands to run to get things
going.   The setup bits are scripted.