### PR TITLE
Fixes CTA buttons with different texts

### DIFF
--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -6,9 +6,6 @@
   <h3 class="text-lg leading-6 font-medium text-gray-900">
     Ruby on Rails developers
   </h3>
-  <div class="mt-3 sm:mt-0 sm:ml-4">
-    <%= link_to "Add your profile", new_developer_path, class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
-  </div>
 </div>
 
 <ul id="developers" role="list" class="space-y-8 bg-gray-100">

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -17,9 +17,6 @@
     <h3 class="text-lg leading-6 font-medium text-gray-900">
       Developers available now
     </h3>
-    <div class="mt-3 sm:mt-0 sm:ml-4">
-      <%= link_to "Add your profile", new_developer_path, class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
-    </div>
   </div>
 
   <ul role="list" class="space-y-8 bg-gray-100">


### PR DESCRIPTION
## Purpose & Approach
The header's main CTA read "Edit your Profile" when signed in, and "Add your Profile" when not signed in.
The CTA on the developer listing views, on both homepage and developers/index pages both read "Add your Profile" even when signed in and a developer profile was already created.

I originally thought making the button dynamic as it's done in the header would be the way to go, but then thought perhaps removing the button altogether would be the way to go since it's a duplicate of the big CTA In the header. If you think this is the wrong path, let me know and we can go with keeping it + making it dynamic and extracting into some sort of component.

![image](https://user-images.githubusercontent.com/300131/141867187-7aaae91c-f780-43d9-829f-600ba2284364.png)

After:
![image](https://user-images.githubusercontent.com/300131/141867219-513b7235-2b1c-411a-b0ff-e82a3db1b257.png)
