### PR TITLE
Introduce length validation on developer.hero column

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,7 +6,7 @@ class Developer < ApplicationRecord
   has_one_attached :cover_image
 
   validates :name, presence: true
-  validates :hero, presence: true
+  validates :hero, presence: true, length: {maximum: 65}
   validates :bio, presence: true
   validates :avatar, content_type: ["image/png", "image/jpg", "image/jpeg"],
     max_file_size: 2.megabytes

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -22,7 +22,7 @@
             <div class="sm:col-span-6">
               <%= form.label :hero, class: "block text-sm font-medium text-gray-700" %>
               <div class="mt-1">
-                <%= form.text_field :hero, class: field_classes(form, :hero) %>
+                <%= form.text_field :hero, class: field_classes(form, :hero), maxlength: 65 %>
               </div>
               <p class="mt-2 text-sm text-gray-500">Summarize yourself as a developer in a few words.</p>
             </div>

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -71,6 +71,13 @@ class DeveloperTest < ActiveSupport::TestCase
     assert_not_nil developer.errors[:bio]
   end
 
+  test "invalid if hero is too long" do
+    @developer.hero = "This is hero text is entirely too long for this field and will be invalid"
+
+    refute @developer.valid?
+    assert_equal @developer.errors[:hero], ["is too long (maximum is 65 characters)"]
+  end
+
   test "available scope is only available developers" do
     travel_to Time.zone.local(2021, 5, 4)
 


### PR DESCRIPTION
## Purpose
When setting up my profile today, I noticed the hero text I entered got cut off on the profile show page. It seems the character length before text starts getting truncated is 65. It would be better if we let the user know they're trying to input a hero that is too long before they save and get taken back to the profile show page

## Approach
Adds a maximum length validation of 65 on `hero` to the `developer` model
Adds a maxlength of 65 to the HTML `input` element