### PR TITLE
Add z-index to fix developer avatar covering mobile menu

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -43,7 +43,7 @@
     </div>
   </div>
 
-  <div data-toggle-target="element" class="hidden absolute z-10 top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden">
+  <div data-toggle-target="element" class="hidden absolute z-10 top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden z-20">
     <div class="rounded-lg shadow-md bg-white ring-1 ring-black ring-opacity-5 overflow-hidden">
       <div class="px-5 pt-4 flex items-center justify-between">
         <div>


### PR DESCRIPTION
Before you submit a pull request for review, please make sure...

- [ ] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project `bundle exec standardrb --fix`

If this PR is not ready for review, please make sure to submit it as a draft.

***
In this PR, I added a z-index to fix the developer avatar covering the mobile menu.
Before the change:
![Screenshot from 2021-11-20 11-21-26](https://user-images.githubusercontent.com/52489421/142721321-cc4c7874-623a-40d2-ac80-3b196676ea0d.png)

After the change:
![Screenshot from 2021-11-20 11-20-56](https://user-images.githubusercontent.com/52489421/142721329-70ba2939-7970-4d16-be56-9b443833e57f.png)


