### PR TITLE
don't allow hero to overflow on smaller screens

### DIFF
--- a/app/components/developer_card_component.html.erb
+++ b/app/components/developer_card_component.html.erb
@@ -4,8 +4,8 @@
   </div>
 
   <div class="self-start flex-1">
-    <div class="flex items-baseline">
-      <h2 class="text-lg sm:text-xl font-medium text-gray-900">
+    <div class="flex items-baseline break-all">
+      <h2 class="text-lg sm:text-xl font-medium text-gray-900" >
         <%= hero %>
       </h2>
 

--- a/app/views/developers/_developer.html.erb
+++ b/app/views/developers/_developer.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="self-start flex-1">
-      <div class="flex items-baseline">
+      <div class="flex items-baseline break-all">
         <h2 class="text-lg sm:text-xl font-medium text-gray-900">
           <%= developer.hero %>
         </h2>


### PR DESCRIPTION
Before you submit a pull request for review, please make sure...

- [x] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project `bundle exec standardrb --fix`


- adds `break-all` from tailwind to break words on overflow on smaller screens. closes https://github.com/joemasilotti/railsdevs.com/issues/113.

Examples

Dev:

<img width="477" alt="Screenshot 2021-11-21 at 02 02 41" src="https://user-images.githubusercontent.com/38360603/142743382-228cf405-1c97-4f4c-a05a-5eee1fd797d3.png">



Prod: 

<img width="307" alt="Screenshot 2021-11-21 at 02 07 24" src="https://user-images.githubusercontent.com/38360603/142743389-ac9ba23a-fecf-4275-a944-b17149c4eaea.png">


> **Screenshots** ![image](https://user-images.githubusercontent.com/2092156/142737607-7b01d35e-94e8-4386-b177-75c0de6efd26.png)


