### PR TITLE
Pundit for authorization only

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -4,7 +4,7 @@ class BusinessesController < ApplicationController
   def new
     authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business
-  rescue BusinessPolicy::AlreadyExists
+  rescue ApplicationPolicy::AlreadyExists
     redirect_to edit_business_path(current_user.business)
   end
 

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,15 +1,12 @@
 class BusinessesController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
+  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
 
   def new
-    authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business
-  rescue ApplicationPolicy::AlreadyExists
-    redirect_to edit_business_path(current_user.business)
   end
 
   def create
-    authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business(business_params)
 
     if @business.save
@@ -37,6 +34,12 @@ class BusinessesController < ApplicationController
   end
 
   private
+
+  def redirect_to_edit_if_already_exists
+    if current_user.business.present?
+      redirect_to edit_business_path(current_user.business)
+    end
+  end
 
   def business_params
     params.require(:business).permit(

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,6 +1,6 @@
 class BusinessesController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
-  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
+  before_action :require_new_business!, only: %i[new create]
 
   def new
     @business = current_user.build_business
@@ -34,7 +34,7 @@ class BusinessesController < ApplicationController
 
   private
 
-  def redirect_to_edit_if_already_exists
+  def require_new_business!
     if current_user.business.present?
       redirect_to edit_business_path(current_user.business)
     end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -10,7 +10,6 @@ class BusinessesController < ApplicationController
     @business = current_user.build_business(business_params)
 
     if @business.save
-      NewBusinessNotification.with(business: @business).deliver_later(User.admin)
       redirect_to developers_path, notice: "Your business was added!"
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -16,7 +16,6 @@ class DevelopersController < ApplicationController
     @developer = current_user.build_developer(developer_params)
 
     if @developer.save
-      NewDeveloperProfileNotification.with(developer: @developer).deliver_later(User.admin)
       redirect_to @developer, notice: "Your profile was added!"
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -2,7 +2,7 @@ class DevelopersController < ApplicationController
   include Pagy::Backend
 
   before_action :authenticate_user!, only: %i[new create edit update]
-  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
+  before_action :require_new_developer!, only: %i[new create]
 
   def index
     @pagy, @developers = pagy(Developer.most_recently_added.with_attached_avatar)
@@ -44,7 +44,7 @@ class DevelopersController < ApplicationController
 
   private
 
-  def redirect_to_edit_if_already_exists
+  def require_new_developer!
     if current_user.developer.present?
       redirect_to edit_developer_path(current_user.developer)
     end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -10,7 +10,7 @@ class DevelopersController < ApplicationController
   def new
     authorize current_user.developer, policy_class: DeveloperPolicy
     @developer = current_user.build_developer
-  rescue DeveloperPolicy::AlreadyExists
+  rescue ApplicationPolicy::AlreadyExists
     redirect_to edit_developer_path(current_user.developer)
   end
 

--- a/app/errors/application_error.rb
+++ b/app/errors/application_error.rb
@@ -1,0 +1,7 @@
+# app/errors/application_error.rb
+class ApplicationError < StandardError
+  # Look up translations via "errors.module_name.class_name".
+  def message
+    I18n.t("errors.#{self.class.name.underscore.tr("/", ".")}")
+  end
+end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -5,4 +5,10 @@ class Business < ApplicationRecord
 
   validates :name, presence: true
   validates :company, presence: true
+
+  after_create :send_admin_notification
+
+  def send_admin_notification
+    NewBusinessNotification.with(business: self).deliver_later(User.admin)
+  end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -28,6 +28,7 @@ class Developer < ApplicationRecord
   scope :most_recently_added, -> { order(created_at: :desc) }
 
   after_initialize :build_role_type, if: -> { role_type.blank? }
+  after_create :send_admin_notification
 
   def preferred_salary_range
     [preferred_min_salary, preferred_max_salary].compact
@@ -35,5 +36,9 @@ class Developer < ApplicationRecord
 
   def preferred_hourly_rate_range
     [preferred_min_hourly_rate, preferred_max_hourly_rate].compact
+  end
+
+  def send_admin_notification
+    NewDeveloperProfileNotification.with(developer: self).deliver_later(User.admin)
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,4 +1,6 @@
 class ApplicationPolicy
+  class AlreadyExists < StandardError; end
+
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/business_policy.rb
+++ b/app/policies/business_policy.rb
@@ -1,14 +1,4 @@
 class BusinessPolicy < ApplicationPolicy
-  def new?
-    raise AlreadyExists unless create?
-
-    true
-  end
-
-  def create?
-    record.nil?
-  end
-
   def update?
     user == record.user
   end

--- a/app/policies/business_policy.rb
+++ b/app/policies/business_policy.rb
@@ -1,6 +1,4 @@
 class BusinessPolicy < ApplicationPolicy
-  class AlreadyExists < StandardError; end
-
   def new?
     raise AlreadyExists unless create?
 
@@ -13,11 +11,5 @@ class BusinessPolicy < ApplicationPolicy
 
   def update?
     user == record.user
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -1,6 +1,4 @@
 class DeveloperPolicy < ApplicationPolicy
-  class AlreadyExists < StandardError; end
-
   def new?
     raise AlreadyExists unless create?
 
@@ -13,11 +11,5 @@ class DeveloperPolicy < ApplicationPolicy
 
   def update?
     user == record.user
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -1,14 +1,4 @@
 class DeveloperPolicy < ApplicationPolicy
-  def new?
-    raise AlreadyExists unless create?
-
-    true
-  end
-
-  def create?
-    record.nil?
-  end
-
   def update?
     user == record.user
   end

--- a/test/fixtures/businesses.yml
+++ b/test/fixtures/businesses.yml
@@ -2,3 +2,8 @@ one:
   user: with_business
   name: Business Owner One
   company: Company One
+
+two:
+  user: with_business_two
+  name: Business Owner Two
+  company: Company Two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -18,6 +18,10 @@ with_business:
   email: business@example.com
   confirmed_at: <%= DateTime.current %>
 
+with_business_two:
+  email: business2@example.com
+  confirmed_at: <%= DateTime.current %>
+
 admin:
   email: admin@example.com
   confirmed_at: <%= DateTime.current %>

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class BusinessesTest < ActionDispatch::IntegrationTest
+  test "can build a new business" do
+    sign_in users(:empty)
+    get new_business_path
+    assert_response :ok
+  end
+
+  test "redirect to edit if building an existing business" do
+    user = users(:with_business)
+    sign_in user
+
+    get new_business_path
+
+    assert_redirected_to edit_business_path(user.business)
+  end
+
+  test "cannot create new business if already has one" do
+    sign_in users(:with_business)
+
+    assert_no_difference "Business.count" do
+      post businesses_path, params: valid_business_params
+    end
+  end
+
+  test "redirect to the edit if they already have a business" do
+    user = users(:with_business)
+    sign_in user
+
+    get new_business_path
+
+    assert_redirected_to edit_business_path(user.business)
+  end
+
+  test "successful business creation" do
+    sign_in users(:empty)
+
+    assert_difference "Business.count", 1 do
+      post businesses_path, params: valid_business_params
+    end
+  end
+
+  test "successful edit to business" do
+    sign_in users(:with_business)
+    business = businesses(:one)
+
+    get edit_business_path(business)
+    assert_select "form"
+
+    patch business_path(business), params: {
+      business: {
+        name: "New Owner Name"
+      }
+    }
+    assert_redirected_to developers_path
+    follow_redirect!
+
+    assert_equal "New Owner Name", business.reload.name
+  end
+
+  test "invalid profile creation" do
+    sign_in users(:empty)
+
+    assert_no_difference "Business.count" do
+      post businesses_path, params: {
+        business: {
+          name: "Business"
+        }
+      }
+    end
+  end
+
+  test "can edit own business" do
+    sign_in users(:with_business)
+    business = businesses(:one)
+
+    get edit_business_path(business)
+    assert_select "form"
+
+    patch business_path(business), params: {
+      business: {
+        name: "New Name"
+      }
+    }
+    assert_redirected_to developers_path
+    assert_equal "New Name", business.reload.name
+  end
+
+  test "cannot edit another business" do
+    sign_in users(:with_business)
+    business = businesses(:two)
+
+    get edit_business_path(business)
+    assert_redirected_to root_path
+
+    assert_no_changes "business.name" do
+      patch business_path(business), params: {
+        business: {
+          name: "New Name"
+        }
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  def valid_business_params
+    {
+      business: {
+        name: "Business Owner",
+        company: "Business, LLC"
+      }
+    }
+  end
+end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -15,23 +15,17 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     sign_in users(:with_available_profile)
 
     assert_no_difference "Developer.count" do
-      post developers_path, params: {
-        developer: {
-          name: "Developer",
-          available_on: Date.yesterday,
-          hero: "A developer",
-          bio: "I develop."
-        }
-      }
+      post developers_path, params: valid_developer_params
     end
   end
 
   test "redirect to the edit profile when they try to enter developers/new, if they already have a profile" do
-    sign_in users(:with_available_profile)
+    user = users(:with_available_profile)
+    sign_in user
 
     get new_developer_path
 
-    assert_redirected_to edit_developer_path(users(:with_available_profile).developer)
+    assert_redirected_to edit_developer_path(user.developer)
   end
 
   test "successful profile creation" do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -64,14 +64,6 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert user.developer.reload.role_type.part_time_contract?
   end
 
-  test "successful profile creation sends a notification to the admin" do
-    sign_in users(:without_profile)
-
-    assert_changes "Notification.count", 1 do
-      post developers_path, params: valid_developer_params
-    end
-  end
-
   test "successful edit to profile" do
     sign_in users(:with_available_profile)
     developer = developers :available

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class BusinessTest < ActiveSupport::TestCase
+  test "successful business creation sends a notification to the admin" do
+    user = users(:empty)
+    assert_changes "Notification.count", 1 do
+      Business.create!(name: "name", company: "company", user: user)
+    end
+  end
+end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -97,4 +97,11 @@ class DeveloperTest < ActiveSupport::TestCase
 
     refute developer.valid?
   end
+
+  test "successful profile creation sends a notification to the admin" do
+    user = users(:without_profile)
+    assert_changes "Notification.count", 1 do
+      Developer.create!(name: "name", hero: "hero", bio: "bio", user: user)
+    end
+  end
 end

--- a/test/policies/business_policy_test.rb
+++ b/test/policies/business_policy_test.rb
@@ -30,7 +30,7 @@ class BusinessPolicyTest < ActiveSupport::TestCase
   test "raises when instantiating a new business when one exists" do
     user = users(:with_business)
 
-    assert_raises(BusinessPolicy::AlreadyExists) do
+    assert_raises(ApplicationPolicy::AlreadyExists) do
       BusinessPolicy.new(user, Business.new).new?
     end
   end

--- a/test/policies/business_policy_test.rb
+++ b/test/policies/business_policy_test.rb
@@ -12,26 +12,4 @@ class BusinessPolicyTest < ActiveSupport::TestCase
 
     refute BusinessPolicy.new(user, business).update?
   end
-
-  test "can create a business profile if they do not already have one" do
-    user = users(:empty)
-    business = user.business
-
-    assert BusinessPolicy.new(user, business).create?
-  end
-
-  test "cannot create a business profile if they already have one" do
-    user = users(:with_business)
-    business = user.business
-
-    refute BusinessPolicy.new(user, business).create?
-  end
-
-  test "raises when instantiating a new business when one exists" do
-    user = users(:with_business)
-
-    assert_raises(ApplicationPolicy::AlreadyExists) do
-      BusinessPolicy.new(user, Business.new).new?
-    end
-  end
 end

--- a/test/policies/developer_policy_test.rb
+++ b/test/policies/developer_policy_test.rb
@@ -12,26 +12,4 @@ class DeveloperPolicyTest < ActiveSupport::TestCase
 
     refute DeveloperPolicy.new(user, developer).update?
   end
-
-  test "can create a developer profile if they do not already have one" do
-    user = users(:without_profile)
-    developer = user.developer
-
-    assert DeveloperPolicy.new(user, developer).create?
-  end
-
-  test "cannot create a developer profile if they already have one" do
-    user = users(:with_available_profile)
-    developer = user.developer
-
-    refute DeveloperPolicy.new(user, developer).create?
-  end
-
-  test "raises when instantiating a new developer when one exists" do
-    user = users(:with_available_profile)
-
-    assert_raises(ApplicationPolicy::AlreadyExists) do
-      DeveloperPolicy.new(user, Developer.new).new?
-    end
-  end
 end

--- a/test/policies/developer_policy_test.rb
+++ b/test/policies/developer_policy_test.rb
@@ -30,7 +30,7 @@ class DeveloperPolicyTest < ActiveSupport::TestCase
   test "raises when instantiating a new developer when one exists" do
     user = users(:with_available_profile)
 
-    assert_raises(DeveloperPolicy::AlreadyExists) do
+    assert_raises(ApplicationPolicy::AlreadyExists) do
       DeveloperPolicy.new(user, Developer.new).new?
     end
   end


### PR DESCRIPTION
In implementing #120, I realized that I was starting to put business logic inside of the Pundit policy classes. These classes should only contain logic related to authorization. This PR moves the business logic into controller `before_action` calls. It also adds some missing tests for `Business` and cleans up the controllers a bit.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project with `bundle exec standardrb --fix`
- [x] You have linted the project with `bundle exec erblint --lint-all --autocorrect`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
