### PR TITLE
Message a developer

### DIFF
--- a/app/components/time_component.html.erb
+++ b/app/components/time_component.html.erb
@@ -1,0 +1,3 @@
+<%= time_tag time do %>
+  <%= time_ago_in_words time %> ago
+<% end %>

--- a/app/components/time_component.rb
+++ b/app/components/time_component.rb
@@ -1,0 +1,7 @@
+class TimeComponent < ApplicationComponent
+  attr_reader :time
+
+  def initialize(time)
+    @time = time
+  end
+end

--- a/app/components/user_menu/signed_in_component.html.erb
+++ b/app/components/user_menu/signed_in_component.html.erb
@@ -1,12 +1,21 @@
-<div data-controller="toggle" data-toggle-close-class="hidden" class="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+<div class="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
   <% if business? %>
-    <%= link_to new_business_path, class: "bg-gray-800 p-1 rounded-full text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white" do %>
-      <span class="sr-only">Edit business</span>
-      <%= inline_svg_tag "icons/outline/briefcase.svg", class: "h-6 w-6" %>
-    <% end %>
+    <div data-controller="toggle" data-toggle-close-class="hidden">
+      <div>
+        <button type="button" data-action="toggle#toggle" class="bg-gray-800 p-1 rounded-full text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white" id="business-menu-button" aria-expanded="false" aria-haspopup="true">
+          <span class="sr-only">Open business menu</span>
+          <%= inline_svg_tag "icons/outline/briefcase.svg", class: "h-6 w-6" %>
+        </button>
+      </div>
+
+      <div data-toggle-target="element" class="hidden origin-top-right absolute right-0 z-10 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="business-menu-button" tabindex="-1">
+        <%= link_to "My business profile", new_business_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+        <%= link_to "My conversations", conversations_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+      </div>
+    </div>
   <% end %>
 
-  <div class="ml-3 relative">
+  <div data-controller="toggle" data-toggle-close-class="hidden" class="ml-3 relative">
     <div>
       <button type="button" data-action="toggle#toggle" class="bg-gray-800 flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
         <span class="sr-only">Open user menu</span>
@@ -15,8 +24,8 @@
     </div>
 
     <div data-toggle-target="element" class="hidden origin-top-right absolute right-0 z-10 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button" tabindex="-1">
-      <%= link_to "My developer profile", new_developer_path, role: "menuitem", tabindex: "-1", id: "user-menu-item-0", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-      <%= button_to "Sign out", destroy_user_session_path, method: :delete, title: "Sign out", role: "menuitem", tabindex: "-1", data: {turbo: false}, class: "bg-transparent block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer w-full text-left" %>
+      <%= link_to "My developer profile", new_developer_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+      <%= button_to "Sign out", destroy_user_session_path, method: :delete, role: "menuitem", tabindex: "-1", data: {turbo: false}, class: "bg-transparent block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer w-full text-left" %>
     </div>
   </div>
 </div>

--- a/app/components/user_menu/signed_in_component.html.erb
+++ b/app/components/user_menu/signed_in_component.html.erb
@@ -10,7 +10,10 @@
 
       <div data-toggle-target="element" class="hidden origin-top-right absolute right-0 z-10 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="business-menu-button" tabindex="-1">
         <%= link_to "My business profile", new_business_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-        <%= link_to "My conversations", conversations_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+
+        <% if Feature.enabled?(:messaging) %>
+          <%= link_to "My conversations", conversations_path, role: "menuitem", tabindex: "-1", class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -4,7 +4,7 @@ class BusinessesController < ApplicationController
   def new
     authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business
-  rescue BusinessPolicy::AlreadyExists
+  rescue ApplicationPolicy::AlreadyExists
     redirect_to edit_business_path(current_user.business)
   end
 

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,15 +1,12 @@
 class BusinessesController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
+  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
 
   def new
-    authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business
-  rescue ApplicationPolicy::AlreadyExists
-    redirect_to edit_business_path(current_user.business)
   end
 
   def create
-    authorize current_user.business, policy_class: BusinessPolicy
     @business = current_user.build_business(business_params)
 
     if @business.save
@@ -37,6 +34,12 @@ class BusinessesController < ApplicationController
   end
 
   private
+
+  def redirect_to_edit_if_already_exists
+    if current_user.business.present?
+      redirect_to edit_business_path(current_user.business)
+    end
+  end
 
   def business_params
     params.require(:business).permit(

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -1,6 +1,6 @@
 class BusinessesController < ApplicationController
   before_action :authenticate_user!, only: %i[new create]
-  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
+  before_action :require_new_business!, only: %i[new create]
 
   def new
     @business = current_user.build_business
@@ -34,7 +34,7 @@ class BusinessesController < ApplicationController
 
   private
 
-  def redirect_to_edit_if_already_exists
+  def require_new_business!
     if current_user.business.present?
       redirect_to edit_business_path(current_user.business)
     end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -10,7 +10,6 @@ class BusinessesController < ApplicationController
     @business = current_user.build_business(business_params)
 
     if @business.save
-      NewBusinessNotification.with(business: @business).deliver_later(User.admin)
       redirect_to developers_path, notice: "Your business was added!"
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,6 +1,10 @@
 class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @conversations = current_user.business.conversations
+  end
+
   def show
     @conversation = Conversation.find_by!(developer: developer, business: current_user.business)
     authorize @conversation

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,53 +1,14 @@
 class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
-  rescue_from ConversationPolicy::MissingBusiness, with: :missing_business
-  rescue_from ConversationPolicy::AlreadyExists, with: :existing_conversation
-
-  def new
-    @conversation = build_conversation
-    authorize @conversation, policy_class: ConversationPolicy
-    @conversation.messages.build
-  end
-
-  def create
-    @conversation = Conversation.new(conversation_params)
-    authorize @conversation, policy_class: ConversationPolicy
-    if @conversation.save
-      redirect_to @conversation
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
   def show
-    @conversation = Conversation.find(params[:id])
-    authorize @conversation, policy_class: ConversationPolicy
+    @conversation = Conversation.find_by!(developer: developer, business: current_user.business)
+    authorize @conversation
   end
 
   private
 
-  def missing_business(e)
-    redirect_to new_business_path, notice: e.message
-  end
-
-  def existing_conversation(e)
-    redirect_to e.conversation
-  end
-
-  def build_conversation
-    developer = Developer.find(params[:developer_id])
-    business = current_user.business
-    Conversation.find_or_initialize_by(developer: developer, business: business)
-  end
-
-  def conversation_params
-    params.require(:conversation).permit(
-      :developer_id,
-      :business_id,
-      messages_attributes: [
-        :body
-      ]
-    )
+  def developer
+    Developer.find(params[:developer_id])
   end
 end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,0 +1,53 @@
+class ConversationsController < ApplicationController
+  before_action :authenticate_user!
+
+  rescue_from ConversationPolicy::MissingBusiness, with: :missing_business
+  rescue_from ConversationPolicy::AlreadyExists, with: :existing_conversation
+
+  def new
+    @conversation = build_conversation
+    authorize @conversation, policy_class: ConversationPolicy
+    @conversation.messages.build
+  end
+
+  def create
+    @conversation = Conversation.new(conversation_params)
+    authorize @conversation, policy_class: ConversationPolicy
+    if @conversation.save
+      redirect_to @conversation
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @conversation = Conversation.find(params[:id])
+    authorize @conversation, policy_class: ConversationPolicy
+  end
+
+  private
+
+  def missing_business(e)
+    redirect_to new_business_path, notice: e.message
+  end
+
+  def existing_conversation(e)
+    redirect_to e.conversation
+  end
+
+  def build_conversation
+    developer = Developer.find(params[:developer_id])
+    business = current_user.business
+    Conversation.find_or_initialize_by(developer: developer, business: business)
+  end
+
+  def conversation_params
+    params.require(:conversation).permit(
+      :developer_id,
+      :business_id,
+      messages_attributes: [
+        :body
+      ]
+    )
+  end
+end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -16,7 +16,6 @@ class DevelopersController < ApplicationController
     @developer = current_user.build_developer(developer_params)
 
     if @developer.save
-      NewDeveloperProfileNotification.with(developer: @developer).deliver_later(User.admin)
       redirect_to @developer, notice: "Your profile was added!"
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -2,7 +2,7 @@ class DevelopersController < ApplicationController
   include Pagy::Backend
 
   before_action :authenticate_user!, only: %i[new create edit update]
-  before_action :redirect_to_edit_if_already_exists, only: %i[new create]
+  before_action :require_new_developer!, only: %i[new create]
 
   def index
     @pagy, @developers = pagy(Developer.most_recently_added.with_attached_avatar)
@@ -44,7 +44,7 @@ class DevelopersController < ApplicationController
 
   private
 
-  def redirect_to_edit_if_already_exists
+  def require_new_developer!
     if current_user.developer.present?
       redirect_to edit_developer_path(current_user.developer)
     end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -10,7 +10,7 @@ class DevelopersController < ApplicationController
   def new
     authorize current_user.developer, policy_class: DeveloperPolicy
     @developer = current_user.build_developer
-  rescue DeveloperPolicy::AlreadyExists
+  rescue ApplicationPolicy::AlreadyExists
     redirect_to edit_developer_path(current_user.developer)
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,45 @@
+class MessagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_business!
+  before_action :require_new_conversation!
+
+  def new
+    @message = Message.new(conversation: conversation)
+  end
+
+  def create
+    @message = Message.new(message_params.merge(conversation: conversation))
+    if @message.save
+      redirect_to [developer, :conversation]
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def require_business!
+    unless current_user.business.present?
+      redirect_to new_business_path, notice: I18n.t("errors.business_blank")
+    end
+  end
+
+  def require_new_conversation!
+    redirect_to [developer, :conversation] unless conversation.new_record?
+  end
+
+  def conversation
+    Conversation.find_or_initialize_by(
+      developer: developer,
+      business: current_user.business
+    )
+  end
+
+  def developer
+    Developer.find(params[:developer_id])
+  end
+
+  def message_params
+    params.require(:message).permit(:body)
+  end
+end

--- a/app/errors/application_error.rb
+++ b/app/errors/application_error.rb
@@ -1,7 +1,0 @@
-# app/errors/application_error.rb
-class ApplicationError < StandardError
-  # Look up translations via "errors.module_name.class_name".
-  def message
-    I18n.t("errors.#{self.class.name.underscore.tr("/", ".")}")
-  end
-end

--- a/app/errors/application_error.rb
+++ b/app/errors/application_error.rb
@@ -1,0 +1,7 @@
+# app/errors/application_error.rb
+class ApplicationError < StandardError
+  # Look up translations via "errors.module_name.class_name".
+  def message
+    I18n.t("errors.#{self.class.name.underscore.tr("/", ".")}")
+  end
+end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -5,4 +5,10 @@ class Business < ApplicationRecord
 
   validates :name, presence: true
   validates :company, presence: true
+
+  after_create :send_admin_notification
+
+  def send_admin_notification
+    NewBusinessNotification.with(business: self).deliver_later(User.admin)
+  end
 end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -2,6 +2,7 @@ class Business < ApplicationRecord
   include Avatarable
 
   belongs_to :user
+  has_many :conversations
 
   validates :name, presence: true
   validates :company, presence: true

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,10 @@
+class Conversation < ApplicationRecord
+  belongs_to :developer
+  belongs_to :business
+
+  has_many :messages, dependent: :destroy
+
+  validates :developer_id, uniqueness: {scope: :business_id}
+
+  accepts_nested_attributes_for :messages
+end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -28,6 +28,7 @@ class Developer < ApplicationRecord
   scope :most_recently_added, -> { order(created_at: :desc) }
 
   after_initialize :build_role_type, if: -> { role_type.blank? }
+  after_create :send_admin_notification
 
   def preferred_salary_range
     [preferred_min_salary, preferred_max_salary].compact
@@ -35,5 +36,9 @@ class Developer < ApplicationRecord
 
   def preferred_hourly_rate_range
     [preferred_min_hourly_rate, preferred_max_hourly_rate].compact
+  end
+
+  def send_admin_notification
+    NewDeveloperProfileNotification.with(developer: self).deliver_later(User.admin)
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -9,6 +9,7 @@ class Developer < ApplicationRecord
   }
 
   belongs_to :user
+  has_many :conversations
   has_one :role_type, dependent: :destroy, autosave: true
   has_one_attached :cover_image
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  belongs_to :conversation
+  has_one :developer, through: :conversation
+  has_one :business, through: :conversation
+
+  validates :body, presence: true
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,4 +1,6 @@
 class ApplicationPolicy
+  class AlreadyExists < StandardError; end
+
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,4 @@
 class ApplicationPolicy
-  class AlreadyExists < StandardError; end
-
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/business_policy.rb
+++ b/app/policies/business_policy.rb
@@ -1,14 +1,4 @@
 class BusinessPolicy < ApplicationPolicy
-  def new?
-    raise AlreadyExists unless create?
-
-    true
-  end
-
-  def create?
-    record.nil?
-  end
-
   def update?
     user == record.user
   end

--- a/app/policies/business_policy.rb
+++ b/app/policies/business_policy.rb
@@ -1,6 +1,4 @@
 class BusinessPolicy < ApplicationPolicy
-  class AlreadyExists < StandardError; end
-
   def new?
     raise AlreadyExists unless create?
 
@@ -13,11 +11,5 @@ class BusinessPolicy < ApplicationPolicy
 
   def update?
     user == record.user
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,34 +1,5 @@
 class ConversationPolicy < ApplicationPolicy
-  class MissingBusiness < ApplicationError; end
-
-  class AlreadyExists < ApplicationError
-    attr_reader :conversation
-
-    def initialize(conversation)
-      @conversation = conversation
-    end
-  end
-
-  def create?
-    raise MissingBusiness if user.business.blank?
-    if (conversation = existing_conversation)
-      raise AlreadyExists.new(conversation)
-    end
-    true
-  end
-
   def show?
-    raise MissingBusiness if user.business.blank?
-    true
-  end
-
-  private
-
-  def conversation_exists?
-    Conversation.exists?(record.attributes.slice(*%w[business_id developer_id]))
-  end
-
-  def existing_conversation
-    Conversation.find_by(record.attributes.slice(*%w[business_id developer_id]))
+    user.business == record.business
   end
 end

--- a/app/policies/conversation_policy.rb
+++ b/app/policies/conversation_policy.rb
@@ -1,0 +1,34 @@
+class ConversationPolicy < ApplicationPolicy
+  class MissingBusiness < ApplicationError; end
+
+  class AlreadyExists < ApplicationError
+    attr_reader :conversation
+
+    def initialize(conversation)
+      @conversation = conversation
+    end
+  end
+
+  def create?
+    raise MissingBusiness if user.business.blank?
+    if (conversation = existing_conversation)
+      raise AlreadyExists.new(conversation)
+    end
+    true
+  end
+
+  def show?
+    raise MissingBusiness if user.business.blank?
+    true
+  end
+
+  private
+
+  def conversation_exists?
+    Conversation.exists?(record.attributes.slice(*%w[business_id developer_id]))
+  end
+
+  def existing_conversation
+    Conversation.find_by(record.attributes.slice(*%w[business_id developer_id]))
+  end
+end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -1,6 +1,4 @@
 class DeveloperPolicy < ApplicationPolicy
-  class AlreadyExists < StandardError; end
-
   def new?
     raise AlreadyExists unless create?
 
@@ -13,11 +11,5 @@ class DeveloperPolicy < ApplicationPolicy
 
   def update?
     user == record.user
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -1,14 +1,4 @@
 class DeveloperPolicy < ApplicationPolicy
-  def new?
-    raise AlreadyExists unless create?
-
-    true
-  end
-
-  def create?
-    record.nil?
-  end
-
   def update?
     user == record.user
   end

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -1,0 +1,22 @@
+<li>
+  <%= link_to developer_conversation_path(conversation.developer), class: "block max-w-prose mx-auto bg-white px-4 py-6 shadow sm:p-6 sm:rounded-lg hover:bg-gray-50 hover:shadow-lg" do %>
+    <div>
+      <div class="flex space-x-3">
+        <div class="flex-shrink-0">
+          <%= render AvatarComponent.new(avatarable: conversation.developer, classes: "h-10 w-10") %>
+        </div>
+
+        <div class="min-w-0 flex-1">
+          <h2 class="text-sm font-medium text-gray-900"><%= conversation.developer.hero %></h2>
+          <p class="text-sm text-gray-500">
+            <%= render TimeComponent.new(conversation.messages.last.created_at) %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-4 text-sm text-gray-700 space-y-4">
+      <%= conversation.messages.last.body %>
+    </div>
+  <% end %>
+</li>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -3,29 +3,7 @@
 
   <div class="mt-8">
     <ul role="list" class="space-y-4">
-      <% @conversations.each do |conversation| %>
-        <li>
-          <%= link_to developer_conversation_path(conversation.developer), class: "block max-w-prose mx-auto bg-white px-4 py-6 shadow sm:p-6 sm:rounded-lg hover:bg-gray-50 hover:shadow-lg" do %>
-            <div>
-              <div class="flex space-x-3">
-                <div class="flex-shrink-0">
-                  <%= render AvatarComponent.new(avatarable: conversation.developer, classes: "h-10 w-10") %>
-                </div>
-
-                <div class="min-w-0 flex-1">
-                  <p class="text-sm font-medium text-gray-900"><%= conversation.developer.hero %></p>
-                  <p class="text-sm text-gray-500">
-                    <%= render TimeComponent.new(conversation.messages.last.created_at) %>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="mt-4 text-sm text-gray-700 space-y-4">
-              <%= conversation.messages.last.body %>
-            </div>
-          <% end %>
-        </li>
-      <% end %>
+      <%= render @conversations %>
     </ul>
   </div>
 </div>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,0 +1,33 @@
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <h1 class="mt-6 text-center text-3xl font-extrabold">Your conversations</h1>
+
+  <div class="mt-8">
+    <ul role="list" class="space-y-4">
+      <% @conversations.each do |conversation| %>
+        <li>
+          <%= link_to developer_conversation_path(conversation.developer), class: "block max-w-prose mx-auto bg-white px-4 py-6 shadow sm:p-6 sm:rounded-lg hover:bg-gray-50 hover:shadow-lg" do %>
+            <div>
+              <div class="flex space-x-3">
+                <div class="flex-shrink-0">
+                  <%= render AvatarComponent.new(avatarable: conversation.developer, classes: "h-10 w-10") %>
+                </div>
+
+                <div class="min-w-0 flex-1">
+                  <p class="text-sm font-medium text-gray-900"><%= conversation.developer.hero %></p>
+                  <p class="text-sm text-gray-500">
+                    <%= time_tag conversation.messages.last.created_at do %>
+                      <%= time_ago_in_words conversation.messages.last.created_at %> ago
+                    <% end %>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="mt-4 text-sm text-gray-700 space-y-4">
+              <%= conversation.messages.last.body %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -15,9 +15,7 @@
                 <div class="min-w-0 flex-1">
                   <p class="text-sm font-medium text-gray-900"><%= conversation.developer.hero %></p>
                   <p class="text-sm text-gray-500">
-                    <%= time_tag conversation.messages.last.created_at do %>
-                      <%= time_ago_in_words conversation.messages.last.created_at %> ago
-                    <% end %>
+                    <%= render TimeComponent.new(conversation.messages.last.created_at) %>
                   </p>
                 </div>
               </div>

--- a/app/views/conversations/new.html.erb
+++ b/app/views/conversations/new.html.erb
@@ -1,0 +1,54 @@
+<%= render "shared/error_messages", resource: @conversation %>
+
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-lg">
+    <h1 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+      Start a conversation
+    </h1>
+
+    <div class="flex items-center justify-center space-x-2 mt-2 text-center text-sm text-gray-600">
+      <div class="block">with</div>
+      <%= link_to @conversation.developer, class: "flex items-center space-x-2 group" do %>
+        <%= render AvatarComponent.new(avatarable: @conversation.developer, classes: "h-8 w-8") %>
+        <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @conversation.developer.hero %></span>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+    <div class="flex items-start space-x-4">
+      <div class="flex-shrink-0">
+        <%= render AvatarComponent.new(avatarable: @conversation.business, classes: "inline-block h-10 w-10 rounded-full") %>
+      </div>
+      <div class="min-w-0 flex-1">
+        <%= form_with model: @conversation, class: "relative" do |form| %>
+          <%= form.hidden_field :developer_id %>
+          <%= form.hidden_field :business_id %>
+
+          <%= form.fields_for :messages do |message| %>
+            <div class="border border-gray-300 rounded-lg shadow-sm overflow-hidden focus-within:border-gray-500 focus-within:ring-1 focus-within:ring-gray-500">
+              <label for="comment" class="sr-only">Add your comment</label>
+              <%= message.text_area :body, rows: 4, placeholder: "Add your message...", class: "block w-full py-3 border-0 resize-none focus:ring-0 sm:text-sm" %>
+
+              <!-- Spacer element to match the height of the toolbar -->
+              <div class="py-2" aria-hidden="true">
+                <!-- Matches height of button in toolbar (1px border + 36px content height) -->
+                <div class="py-px">
+                  <div class="h-9"></div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
+          <div class="absolute bottom-0 inset-x-0 pl-3 pr-2 py-2 flex justify-end">
+            <div class="flex-shrink-0">
+              <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                Send
+              </button>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -1,0 +1,17 @@
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <h1 class="mt-6 text-center text-3xl">
+    <span class="font-extrabold">Conversation</span>
+
+    <div class="flex items-center justify-center space-x-2 mt-2 text-center text-sm text-gray-600">
+      <div class="block">with</div>
+      <%= link_to @conversation.developer, class: "flex items-center space-x-2 group" do %>
+        <%= render AvatarComponent.new(avatarable: @conversation.developer, classes: "h-8 w-8") %>
+        <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @conversation.developer.hero %></span>
+      <% end %>
+    </div>
+  </h1>
+
+  <ul role="list" class="mt-8 space-y-2 sm:px-6 sm:space-y-4 lg:px-8">
+    <%= render @conversation.messages %>
+  </ul>
+</div>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -21,7 +21,7 @@
                 <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
 
                 <div class="mt-4 flex space-x-3 md:mt-0">
-                  <%= link_to new_developer_conversation_path(@developer), class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+                  <%= link_to new_developer_message_path(@developer), class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
                     <%= inline_svg_tag "icons/solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
                     <span>Message</span>
                   <% end %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -20,12 +20,14 @@
               <div class="md:flex md:items-center md:justify-between md:space-x-4 lg:border-b lg:pb-6">
                 <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
 
-                <div class="mt-4 flex space-x-3 md:mt-0">
-                  <%= link_to new_developer_message_path(@developer), class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
-                    <%= inline_svg_tag "icons/solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
-                    <span>Message</span>
-                  <% end %>
-                </div>
+                <% if Feature.enabled?(:messaging) %>
+                  <div class="mt-4 flex space-x-3 md:mt-0">
+                    <%= link_to new_developer_message_path(@developer), class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+                      <%= inline_svg_tag "icons/solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
+                      <span>Message</span>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
 
               <aside class="mt-8 lg:hidden">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -19,6 +19,13 @@
             <div>
               <div class="md:flex md:items-center md:justify-between md:space-x-4 lg:border-b lg:pb-6">
                 <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
+
+                <div class="mt-4 flex space-x-3 md:mt-0">
+                  <%= link_to new_developer_conversation_path(@developer), class: "inline-flex justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+                    <%= inline_svg_tag "icons/solid/mail", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
+                    <span>Message</span>
+                  <% end %>
+                </div>
               </div>
 
               <aside class="mt-8 lg:hidden">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,9 +6,7 @@
     </h3>
 
     <p class="mt-1 text-sm text-gray-600 whitespace-nowrap sm:mt-0 sm:ml-3">
-      <%= time_tag message.created_at do %>
-        <%= time_ago_in_words message.created_at %> ago
-      <% end %>
+      <%= render TimeComponent.new(message.created_at) %>
     </p>
   </div>
 

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,0 +1,18 @@
+<li class="max-w-prose mx-auto bg-white px-4 py-6 shadow sm:rounded-lg sm:px-6">
+  <div class="sm:flex sm:justify-between sm:items-baseline">
+    <h3 class="text-base font-medium">
+      <span class="text-gray-900">You</span>
+      <span class="text-gray-600">wrote</span>
+    </h3>
+
+    <p class="mt-1 text-sm text-gray-600 whitespace-nowrap sm:mt-0 sm:ml-3">
+    <%= time_tag message.created_at do %>
+      <%= time_ago_in_words message.created_at %> ago
+    <% end %>
+    </p>
+  </div>
+
+  <div class="mt-4 space-y-6 text-sm text-gray-800">
+    <p><%= message.body %></p>
+  </div>
+</li>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,9 +6,9 @@
     </h3>
 
     <p class="mt-1 text-sm text-gray-600 whitespace-nowrap sm:mt-0 sm:ml-3">
-    <%= time_tag message.created_at do %>
-      <%= time_ago_in_words message.created_at %> ago
-    <% end %>
+      <%= time_tag message.created_at do %>
+        <%= time_ago_in_words message.created_at %> ago
+      <% end %>
     </p>
   </div>
 

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,0 +1,49 @@
+<%= render "shared/error_messages", resource: @message %>
+
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-lg">
+    <h1 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+      Start a conversation
+    </h1>
+
+    <div class="flex items-center justify-center space-x-2 mt-2 text-center text-sm text-gray-600">
+      <div class="block">with</div>
+      <%= link_to @message.conversation.developer, class: "flex items-center space-x-2 group" do %>
+        <%= render AvatarComponent.new(avatarable: @message.conversation.developer, classes: "h-8 w-8") %>
+        <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @message.conversation.developer.hero %></span>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
+    <div class="flex items-start space-x-4">
+      <div class="flex-shrink-0">
+        <%= render AvatarComponent.new(avatarable: @message.conversation.business, classes: "inline-block h-10 w-10 rounded-full") %>
+      </div>
+      <div class="min-w-0 flex-1">
+        <%= form_with model: [@message.conversation.developer, @message], class: "relative" do |form| %>
+          <div class="border border-gray-300 rounded-lg shadow-sm overflow-hidden focus-within:border-gray-500 focus-within:ring-1 focus-within:ring-gray-500">
+            <%= form.label :body, "Add your message", class: "sr-only" %>
+            <%= form.text_area :body, rows: 4, placeholder: "Add your message...", class: "block w-full py-3 border-0 resize-none focus:ring-0 sm:text-sm" %>
+
+            <!-- Spacer element to match the height of the toolbar -->
+            <div class="py-2" aria-hidden="true">
+              <!-- Matches height of button in toolbar (1px border + 36px content height) -->
+              <div class="py-px">
+                <div class="h-9"></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="absolute bottom-0 inset-x-0 pl-3 pr-2 py-2 flex justify-end">
+            <div class="flex-shrink-0">
+              <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                Send
+              </button>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -16,11 +16,11 @@
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-xl">
-    <div class="flex items-start space-x-4">
-      <div class="flex-shrink-0">
+    <div class="flex items-start sm:space-x-4">
+      <div class="hidden sm:block flex-shrink-0">
         <%= render AvatarComponent.new(avatarable: @message.conversation.business, classes: "inline-block h-10 w-10 rounded-full") %>
       </div>
-      <div class="min-w-0 flex-1">
+      <div class="min-w-0 flex-1 px-4 sm:px-0">
         <%= form_with model: [@message.conversation.developer, @message], class: "relative" do |form| %>
           <div class="border border-gray-300 rounded-lg shadow-sm overflow-hidden focus-within:border-gray-500 focus-within:ring-1 focus-within:ring-gray-500">
             <%= form.label :body, "Add your message", class: "sr-only" %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="flex items-center justify-center space-x-2 mt-2 text-center text-sm text-gray-600">
       <div class="block">with</div>
-      <%= link_to @message.conversation.developer, class: "flex items-center space-x-2 group" do %>
+      <%= link_to developer_path(@message.conversation.developer), class: "flex items-center space-x-2 group" do %>
         <%= render AvatarComponent.new(avatarable: @message.conversation.developer, classes: "h-8 w-8") %>
         <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @message.conversation.developer.hero %></span>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
     messages:
       content_type_invalid: image format not supported
       max_file_size_invalid: image over %{size}
+    conversation_policy:
+      missing_business: Fill out your business profile to message developers.
 
   helpers:
     submit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,7 @@ en:
     messages:
       content_type_invalid: image format not supported
       max_file_size_invalid: image over %{size}
-    conversation_policy:
-      missing_business: Fill out your business profile to message developers.
+    business_blank: Fill out your business profile to message developers.
 
   helpers:
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,10 @@ Rails.application.routes.draw do
   resource :home, only: :show
   resource :role, only: :new
   resources :businesses, only: %i[new create edit update]
-  resources :conversations, only: %i[create show]
 
   resources :developers, except: :destroy do
-    resources :conversations, only: :new
+    resource :conversation, only: :show
+    resources :messages, only: %i[new create]
   end
 
   root to: "home#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   resource :home, only: :show
   resource :role, only: :new
   resources :businesses, only: %i[new create edit update]
-  resources :developers, except: :destroy
+  resources :conversations, only: %i[create show]
+
+  resources :developers, except: :destroy do
+    resources :conversations, only: :new
+  end
 
   root to: "home#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resource :home, only: :show
   resource :role, only: :new
   resources :businesses, only: %i[new create edit update]
+  resources :conversations, only: :index
 
   resources :developers, except: :destroy do
     resource :conversation, only: :show

--- a/db/migrate/20211201185033_create_conversations_and_messages.rb
+++ b/db/migrate/20211201185033_create_conversations_and_messages.rb
@@ -1,0 +1,17 @@
+class CreateConversationsAndMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conversations do |t|
+      t.belongs_to :developer
+      t.belongs_to :business
+
+      t.timestamps
+    end
+
+    create_table :messages do |t|
+      t.belongs_to :conversation
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_095707) do
+ActiveRecord::Schema.define(version: 2021_12_01_185033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,15 @@ ActiveRecord::Schema.define(version: 2021_11_28_095707) do
     t.index ["user_id"], name: "index_businesses_on_user_id"
   end
 
+  create_table "conversations", force: :cascade do |t|
+    t.bigint "developer_id"
+    t.bigint "business_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["business_id"], name: "index_conversations_on_business_id"
+    t.index ["developer_id"], name: "index_conversations_on_developer_id"
+  end
+
   create_table "developers", force: :cascade do |t|
     t.string "name", null: false
     t.string "email"
@@ -70,6 +79,14 @@ ActiveRecord::Schema.define(version: 2021_11_28_095707) do
     t.integer "preferred_max_hourly_rate"
     t.integer "preferred_min_salary"
     t.integer "preferred_max_salary"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "conversation_id"
+    t.text "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["conversation_id"], name: "index_messages_on_conversation_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/test/components/time_component_test.rb
+++ b/test/components/time_component_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class TimeComponentTest < ViewComponent::TestCase
+  test "renders the timestamp and human readable" do
+    time = Time.zone.local(2021, 6, 26, 0, 59)
+
+    travel_to Time.zone.local(2021, 12, 6) do
+      render_inline TimeComponent.new(time)
+    end
+
+    assert_selector "time[datetime='2021-06-26T00:59:00Z']" do
+      assert_text "5 months ago"
+    end
+  end
+end

--- a/test/fixtures/businesses.yml
+++ b/test/fixtures/businesses.yml
@@ -7,3 +7,8 @@ two:
   user: with_business_two
   name: Business Owner Two
   company: Company Two
+
+with_conversation:
+  user: with_business_conversation
+  name: Business Owner with Conversation
+  company: Conversation Business

--- a/test/fixtures/businesses.yml
+++ b/test/fixtures/businesses.yml
@@ -2,3 +2,8 @@ one:
   user: with_business
   name: Business Owner One
   company: Company One
+
+two:
+  user: with_business_two
+  name: Business Owner Two
+  company: Company Two

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -1,0 +1,3 @@
+one:
+  developer: with_conversation
+  business: with_conversation

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -11,3 +11,9 @@ unavailable:
   available_on: <%= Date.new(2222, 2, 2) %>
   hero: Second developer
   bio: I am the second developer
+
+with_conversation:
+  user: with_developer_conversation
+  name: Developer Three
+  hero: Third developer
+  bio: I am the third developer

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -22,6 +22,14 @@ with_business_two:
   email: business2@example.com
   confirmed_at: <%= DateTime.current %>
 
+with_developer_conversation:
+  email: developer_conversation@example.com
+  confirmed_at: <%= DateTime.current %>
+
+with_business_conversation:
+  email: business_conversation@example.com
+  confirmed_at: <%= DateTime.current %>
+
 admin:
   email: admin@example.com
   confirmed_at: <%= DateTime.current %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -18,6 +18,10 @@ with_business:
   email: business@example.com
   confirmed_at: <%= DateTime.current %>
 
+with_business_two:
+  email: business2@example.com
+  confirmed_at: <%= DateTime.current %>
+
 admin:
   email: admin@example.com
   confirmed_at: <%= DateTime.current %>

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class BusinessesTest < ActionDispatch::IntegrationTest
+  test "can build a new business" do
+    sign_in users(:empty)
+    get new_business_path
+    assert_response :ok
+  end
+
+  test "redirect to edit if building an existing business" do
+    user = users(:with_business)
+    sign_in user
+
+    get new_business_path
+
+    assert_redirected_to edit_business_path(user.business)
+  end
+
+  test "cannot create new business if already has one" do
+    sign_in users(:with_business)
+
+    assert_no_difference "Business.count" do
+      post businesses_path, params: valid_business_params
+    end
+  end
+
+  test "redirect to the edit if they already have a business" do
+    user = users(:with_business)
+    sign_in user
+
+    get new_business_path
+
+    assert_redirected_to edit_business_path(user.business)
+  end
+
+  test "successful business creation" do
+    sign_in users(:empty)
+
+    assert_difference "Business.count", 1 do
+      post businesses_path, params: valid_business_params
+    end
+  end
+
+  test "successful edit to business" do
+    sign_in users(:with_business)
+    business = businesses(:one)
+
+    get edit_business_path(business)
+    assert_select "form"
+
+    patch business_path(business), params: {
+      business: {
+        name: "New Owner Name"
+      }
+    }
+    assert_redirected_to developers_path
+    follow_redirect!
+
+    assert_equal "New Owner Name", business.reload.name
+  end
+
+  test "invalid profile creation" do
+    sign_in users(:empty)
+
+    assert_no_difference "Business.count" do
+      post businesses_path, params: {
+        business: {
+          name: "Business"
+        }
+      }
+    end
+  end
+
+  test "can edit own business" do
+    sign_in users(:with_business)
+    business = businesses(:one)
+
+    get edit_business_path(business)
+    assert_select "form"
+
+    patch business_path(business), params: {
+      business: {
+        name: "New Name"
+      }
+    }
+    assert_redirected_to developers_path
+    assert_equal "New Name", business.reload.name
+  end
+
+  test "cannot edit another business" do
+    sign_in users(:with_business)
+    business = businesses(:two)
+
+    get edit_business_path(business)
+    assert_redirected_to root_path
+
+    assert_no_changes "business.name" do
+      patch business_path(business), params: {
+        business: {
+          name: "New Name"
+        }
+      }
+    end
+    assert_redirected_to root_path
+  end
+
+  def valid_business_params
+    {
+      business: {
+        name: "Business Owner",
+        company: "Business, LLC"
+      }
+    }
+  end
+end

--- a/test/integration/conversations_test.rb
+++ b/test/integration/conversations_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ConversationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @developer = developers(:available)
+    @business = businesses(:one)
+    sign_in @business.user
+  end
+
+  test "starting a new conversation" do
+    get new_developer_conversation_path(@developer)
+    assert_response :ok
+  end
+
+  test "trying to start an existing conversation" do
+    conversation = Conversation.create!(developer: @developer, business: @business)
+    get new_developer_conversation_path(@developer)
+    assert_redirected_to conversation_path(conversation)
+  end
+
+  test "sending a message in a new conversation" do
+    assert_difference "Conversation.count", 1 do
+      assert_difference "Message.count", 1 do
+        post_conversation("Hello!")
+      end
+    end
+
+    assert_redirected_to conversation_path(Conversation.last)
+    follow_redirect!
+    assert_equal Conversation.last.messages.last.body, "Hello!"
+  end
+
+  test "sending a message to an existing conversation" do
+    conversation = Conversation.create!(developer: @developer, business: @business)
+
+    assert_no_difference "Conversation.count" do
+      assert_no_difference "Message.count", 1 do
+        post_conversation("Hello, again!")
+      end
+    end
+
+    assert_redirected_to conversation_path(conversation)
+  end
+
+  def post_conversation(message)
+    post conversations_path(@developer), params: {
+      conversation: {
+        developer_id: @developer.id,
+        business_id: @business.id,
+        messages_attributes: [
+          {
+            body: message
+          }
+        ]
+      }
+    }
+  end
+end

--- a/test/integration/conversations_test.rb
+++ b/test/integration/conversations_test.rb
@@ -1,58 +1,26 @@
 require "test_helper"
 
 class ConversationsTest < ActionDispatch::IntegrationTest
-  setup do
-    @developer = developers(:available)
-    @business = businesses(:one)
-    sign_in @business.user
+  test "you must be signed in" do
+    get developer_conversation_path(conversations(:one))
+    assert_redirected_to new_user_registration_path
   end
 
-  test "starting a new conversation" do
-    get new_developer_conversation_path(@developer)
+  test "viewing your business' conversation" do
+    conversation = conversations(:one)
+    sign_in conversation.business.user
+
+    get developer_conversation_path(conversation.developer)
+
     assert_response :ok
   end
 
-  test "trying to start an existing conversation" do
-    conversation = Conversation.create!(developer: @developer, business: @business)
-    get new_developer_conversation_path(@developer)
-    assert_redirected_to conversation_path(conversation)
-  end
+  test "viewing another business' conversation" do
+    conversation = conversations(:one)
+    sign_in conversation.business.user
 
-  test "sending a message in a new conversation" do
-    assert_difference "Conversation.count", 1 do
-      assert_difference "Message.count", 1 do
-        post_conversation("Hello!")
-      end
-    end
+    get developer_conversation_path(conversation.developer)
 
-    assert_redirected_to conversation_path(Conversation.last)
-    follow_redirect!
-    assert_equal Conversation.last.messages.last.body, "Hello!"
-  end
-
-  test "sending a message to an existing conversation" do
-    conversation = Conversation.create!(developer: @developer, business: @business)
-
-    assert_no_difference "Conversation.count" do
-      assert_no_difference "Message.count", 1 do
-        post_conversation("Hello, again!")
-      end
-    end
-
-    assert_redirected_to conversation_path(conversation)
-  end
-
-  def post_conversation(message)
-    post conversations_path(@developer), params: {
-      conversation: {
-        developer_id: @developer.id,
-        business_id: @business.id,
-        messages_attributes: [
-          {
-            body: message
-          }
-        ]
-      }
-    }
+    assert_response :ok
   end
 end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -15,23 +15,17 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     sign_in users(:with_available_profile)
 
     assert_no_difference "Developer.count" do
-      post developers_path, params: {
-        developer: {
-          name: "Developer",
-          available_on: Date.yesterday,
-          hero: "A developer",
-          bio: "I develop."
-        }
-      }
+      post developers_path, params: valid_developer_params
     end
   end
 
   test "redirect to the edit profile when they try to enter developers/new, if they already have a profile" do
-    sign_in users(:with_available_profile)
+    user = users(:with_available_profile)
+    sign_in user
 
     get new_developer_path
 
-    assert_redirected_to edit_developer_path(users(:with_available_profile).developer)
+    assert_redirected_to edit_developer_path(user.developer)
   end
 
   test "successful profile creation" do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -64,14 +64,6 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert user.developer.reload.role_type.part_time_contract?
   end
 
-  test "successful profile creation sends a notification to the admin" do
-    sign_in users(:without_profile)
-
-    assert_changes "Notification.count", 1 do
-      post developers_path, params: valid_developer_params
-    end
-  end
-
   test "successful edit to profile" do
     sign_in users(:with_available_profile)
     developer = developers :available

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class MessagesTest < ActionDispatch::IntegrationTest
+  setup do
+    @developer = developers(:available)
+    @business = businesses(:one)
+  end
+
+  test "must be signed in" do
+    get new_developer_message_path(@developer)
+    assert_redirected_to new_user_registration_path
+
+    post developer_messages_path(@developer)
+    assert_redirected_to new_user_registration_path
+  end
+
+  test "must have a business profile" do
+    sign_in users(:empty)
+
+    get new_developer_message_path(@developer)
+    assert_redirected_to new_business_path
+
+    post developer_messages_path(@developer)
+    assert_redirected_to new_business_path
+  end
+
+  test "starting a new conversation" do
+    sign_in @business.user
+    get new_developer_message_path(@developer)
+    assert_select "form[action=?]", developer_messages_path(@developer)
+  end
+
+  test "creating a new conversation" do
+    sign_in @business.user
+
+    assert_difference "Message.count", 1 do
+      assert_difference "Conversation.count", 1 do
+        post developer_messages_path(@developer), params: message_params
+      end
+    end
+
+    assert_redirected_to developer_conversation_path(@developer)
+    follow_redirect!
+    assert_select "h1", text: /^Conversation/
+  end
+
+  test "trying to start an existing conversation" do
+    sign_in @business.user
+    Conversation.create!(developer: @developer, business: @business)
+
+    get new_developer_message_path(@developer)
+
+    assert_redirected_to developer_conversation_path(@developer)
+  end
+
+  test "trying to continue an existing conversation" do
+    sign_in @business.user
+    Conversation.create!(developer: @developer, business: @business)
+
+    assert_no_difference "Message.count" do
+      assert_no_difference "Conversation.count" do
+        post developer_messages_path(@developer), params: message_params
+      end
+    end
+
+    assert_redirected_to developer_conversation_path(@developer)
+  end
+
+  def message_params
+    {
+      message: {
+        body: "Hello!"
+      }
+    }
+  end
+end

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class BusinessTest < ActiveSupport::TestCase
+  test "successful business creation sends a notification to the admin" do
+    user = users(:empty)
+    assert_changes "Notification.count", 1 do
+      Business.create!(name: "name", company: "company", user: user)
+    end
+  end
+end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -97,4 +97,11 @@ class DeveloperTest < ActiveSupport::TestCase
 
     refute developer.valid?
   end
+
+  test "successful profile creation sends a notification to the admin" do
+    user = users(:without_profile)
+    assert_changes "Notification.count", 1 do
+      Developer.create!(name: "name", hero: "hero", bio: "bio", user: user)
+    end
+  end
 end

--- a/test/policies/business_policy_test.rb
+++ b/test/policies/business_policy_test.rb
@@ -30,7 +30,7 @@ class BusinessPolicyTest < ActiveSupport::TestCase
   test "raises when instantiating a new business when one exists" do
     user = users(:with_business)
 
-    assert_raises(BusinessPolicy::AlreadyExists) do
+    assert_raises(ApplicationPolicy::AlreadyExists) do
       BusinessPolicy.new(user, Business.new).new?
     end
   end

--- a/test/policies/business_policy_test.rb
+++ b/test/policies/business_policy_test.rb
@@ -12,26 +12,4 @@ class BusinessPolicyTest < ActiveSupport::TestCase
 
     refute BusinessPolicy.new(user, business).update?
   end
-
-  test "can create a business profile if they do not already have one" do
-    user = users(:empty)
-    business = user.business
-
-    assert BusinessPolicy.new(user, business).create?
-  end
-
-  test "cannot create a business profile if they already have one" do
-    user = users(:with_business)
-    business = user.business
-
-    refute BusinessPolicy.new(user, business).create?
-  end
-
-  test "raises when instantiating a new business when one exists" do
-    user = users(:with_business)
-
-    assert_raises(ApplicationPolicy::AlreadyExists) do
-      BusinessPolicy.new(user, Business.new).new?
-    end
-  end
 end

--- a/test/policies/conversation_policy_test.rb
+++ b/test/policies/conversation_policy_test.rb
@@ -2,42 +2,19 @@ require "test_helper"
 
 class ConversationPolicyTest < ActiveSupport::TestCase
   setup do
+    @user = users(:with_business)
     @developer = developers(:available)
   end
 
-  test "create a new conversation" do
-    user = users(:with_business)
-    conversation = Conversation.new(developer: @developer, business: user.business)
-    assert ConversationPolicy.new(user, conversation).create?
+  test "can view their own conversation" do
+    business = @user.business
+    conversation = Conversation.create!(developer: @developer, business: business)
+    assert ConversationPolicy.new(@user, conversation).show?
   end
 
-  test "cannot create a new conversation if no business" do
-    user = users(:empty)
-    conversation = Conversation.new(developer: @developer, business: user.business)
-    assert_raises ConversationPolicy::MissingBusiness do
-      ConversationPolicy.new(user, conversation).create?
-    end
-  end
-
-  test "cannot create a new conversation if one already exists" do
-    user = users(:with_business)
-    conversation = Conversation.create!(developer: @developer, business: user.business)
-    assert_raises ConversationPolicy::AlreadyExists do
-      ConversationPolicy.new(user, conversation).create?
-    end
-  end
-
-  test "cannot view a conversation if no business" do
-    user = users(:empty)
-    conversation = Conversation.create!(developer: @developer, business: businesses(:one))
-    assert_raises ConversationPolicy::MissingBusiness do
-      ConversationPolicy.new(user, conversation).create?
-    end
-  end
-
-  test "can view a conversation" do
-    user = users(:with_business)
-    conversation = Conversation.create!(developer: @developer, business: user.business)
-    assert ConversationPolicy.new(user, conversation).show?
+  test "cannot view another business' conversation" do
+    business = businesses(:two)
+    conversation = Conversation.create!(developer: @developer, business: business)
+    refute ConversationPolicy.new(@user, conversation).show?
   end
 end

--- a/test/policies/conversation_policy_test.rb
+++ b/test/policies/conversation_policy_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class ConversationPolicyTest < ActiveSupport::TestCase
+  setup do
+    @developer = developers(:available)
+  end
+
+  test "create a new conversation" do
+    user = users(:with_business)
+    conversation = Conversation.new(developer: @developer, business: user.business)
+    assert ConversationPolicy.new(user, conversation).create?
+  end
+
+  test "cannot create a new conversation if no business" do
+    user = users(:empty)
+    conversation = Conversation.new(developer: @developer, business: user.business)
+    assert_raises ConversationPolicy::MissingBusiness do
+      ConversationPolicy.new(user, conversation).create?
+    end
+  end
+
+  test "cannot create a new conversation if one already exists" do
+    user = users(:with_business)
+    conversation = Conversation.create!(developer: @developer, business: user.business)
+    assert_raises ConversationPolicy::AlreadyExists do
+      ConversationPolicy.new(user, conversation).create?
+    end
+  end
+
+  test "cannot view a conversation if no business" do
+    user = users(:empty)
+    conversation = Conversation.create!(developer: @developer, business: businesses(:one))
+    assert_raises ConversationPolicy::MissingBusiness do
+      ConversationPolicy.new(user, conversation).create?
+    end
+  end
+
+  test "can view a conversation" do
+    user = users(:with_business)
+    conversation = Conversation.create!(developer: @developer, business: user.business)
+    assert ConversationPolicy.new(user, conversation).show?
+  end
+end

--- a/test/policies/developer_policy_test.rb
+++ b/test/policies/developer_policy_test.rb
@@ -12,26 +12,4 @@ class DeveloperPolicyTest < ActiveSupport::TestCase
 
     refute DeveloperPolicy.new(user, developer).update?
   end
-
-  test "can create a developer profile if they do not already have one" do
-    user = users(:without_profile)
-    developer = user.developer
-
-    assert DeveloperPolicy.new(user, developer).create?
-  end
-
-  test "cannot create a developer profile if they already have one" do
-    user = users(:with_available_profile)
-    developer = user.developer
-
-    refute DeveloperPolicy.new(user, developer).create?
-  end
-
-  test "raises when instantiating a new developer when one exists" do
-    user = users(:with_available_profile)
-
-    assert_raises(ApplicationPolicy::AlreadyExists) do
-      DeveloperPolicy.new(user, Developer.new).new?
-    end
-  end
 end

--- a/test/policies/developer_policy_test.rb
+++ b/test/policies/developer_policy_test.rb
@@ -30,7 +30,7 @@ class DeveloperPolicyTest < ActiveSupport::TestCase
   test "raises when instantiating a new developer when one exists" do
     user = users(:with_available_profile)
 
-    assert_raises(DeveloperPolicy::AlreadyExists) do
+    assert_raises(ApplicationPolicy::AlreadyExists) do
       DeveloperPolicy.new(user, Developer.new).new?
     end
   end


### PR DESCRIPTION
This PR closes #120.

### Features from issue

- [x] Add a Message button to a developer's profile
    - [x] When clicked, if signed in as a business then open a new conversation screen
    - [x] When clicked, if not signed in as a business then prompt to create a business profile
- [x] `developers/:id/messages/new` with an input field
    - [x] Create a `Conversation` that belongs to the developer and business
    - [x] Create a `Message` that belongs to the conversation
    - [x] Can only be access by a business (via `pundit`)
- [x] `conversations` index of all conversations the developer or business is a part of (read only)
    - [x] Link to conversations from header / menu
- [x] `/developers/:id/conversation` show a specific conversation (read only)
    - [x] `pundit` for authorization scopes
- [x] Hide the Message button in production based on the feature flag
- [x] Double check mobile views

### Implementation details

I went through a few different approaches to this feature and I like where I ended up. My thought process was broken down into two categories: (ab)using pundit and routes. Here's some decisions I made and why I made them.

#### (Ab)using pundit

First off, we were kind of abusing pundit. See #129 for more details. But in summary, pundit should be used for authorization, only. We were starting to creep business logic in there.

I started to fall for this trap and was adding logic like raising errors if a business already had a profile then catching them and redirecting in the controller. Not good. Instead, I've opted for a few `before_action` methods that check and do the redirections. This could probably be cleaned up, but I think it reads quite nicely and isn't too complicated (yet).

#### Routes

I spent a lot of time figuring out the best routes for this. My first pass was to POST a `Conversation` and nest the `Message` inside. That fell apart because if there was an error you could use context and you had additional authorization checks because the `Conversation` attributes were coming from the form.

Second, I moved to POST a `Message` and have the `Conversation` `#find_or_create_by`. This worked OK, but I ended up needing to wrap actions in `begin` and rolling back which felt ugly.

[Finally](https://github.com/joemasilotti/railsdevs.com/pull/130/commits/48cf3916fba0ca18750968c15fe36ce0878d391a), I decided to POST to `/developers/:id/messages`. This keeps the `Developer` context (it's in the URL!) and grabbing the `Business` from `current_user`. Much harder to fake. I also like this because your URL is no `/developers/:id/conversation` instead of `/conversations/:id`.

Moving forward, this approach _should_ scale better when we introduce developers viewing their own conversations. The controller will need to determine who is the "context" but then things hopefully fall together nicely.

I hope that ramble helped!

### Pull request checklist

- [x] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project with `bundle exec standardrb --fix`
- [x] You have linted the project with `bundle exec erblint --lint-all --autocorrect`