### PR TITLE
Install hotwire-livereload and Redis in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "sprockets-rails", "~> 3.3", require: "sprockets/railtie"
 gem "view_component", "~> 2.46"
 
 group :development, :test do
+  gem "hotwire-livereload"
   gem "i18n-tasks", "~> 0.9.35"
   gem "letter_opener_web"
   gem "pry-rails"
@@ -22,7 +23,6 @@ end
 
 group :development do
   gem "erb_lint", require: false
-  gem "hotwire-livereload"
   gem "listen", "~> 3.3"
   gem "redis"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,9 @@ end
 
 group :development do
   gem "erb_lint", require: false
+  gem "hotwire-livereload"
   gem "listen", "~> 3.3"
+  gem "redis"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
       activesupport (>= 5.0)
     highline (2.0.3)
     honeybadger (4.9.0)
+    hotwire-livereload (0.2.0)
+      listen (>= 3.0.0)
+      rails (>= 6.0.0)
     hotwire-rails (0.1.3)
       rails (>= 6.0.0)
       stimulus-rails
@@ -267,6 +270,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
+    redis (4.5.1)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -341,6 +345,7 @@ DEPENDENCIES
   devise!
   erb_lint
   honeybadger (~> 4.0)
+  hotwire-livereload
   hotwire-rails (~> 0.1)
   i18n-tasks (~> 0.9.35)
   inline_svg (~> 1.7)
@@ -356,6 +361,7 @@ DEPENDENCIES
   pundit (~> 2.1)
   rails!
   redcarpet (~> 3.5)
+  redis
   sprockets-rails (~> 3.3)
   standard
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You need the following installed:
 
 * Ruby 3.0 or higher
 * [bundler](https://bundler.io) - `gem install bundler`
+* [Redis](https://redis.io) - `brew install redis`
 * [Imagemagick](https://imagemagick.org) - `brew install imagemagick`
 * [Yarn](https://yarnpkg.com) - `brew install yarn`
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,10 @@
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
-    <%= analytics_tag %>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+
+    <%= analytics_tag %>
+    <%= hotwire_livereload_tags %>
   </head>
 
   <body class="min-h-full flex flex-col">

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,4 @@
+development:
+  adapter: redis
+  url: "redis://localhost:6379/1"
+  channel_prefix: railsdevs_development

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,8 @@ Rails.application.configure do
   # "Send" emails to preview with letter opener.
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
+
+  # Watch additional directories for live reloading (outside of app/views, app/helpers, and app/javascript).
+  directories = %w[app/assets/stylesheets app/assets/images app/components]
+  config.hotwire_livereload.listen_paths += directories.map { |p| Rails.root.join(p) }
 end


### PR DESCRIPTION
This PR adds live reload support in development. Changing any files in the following directories will trigger a page reload. This depends on Action Cable, so Redis was installed and configured for development.

* `app/views`
* `app/helpers`
* `app/javascript`
* `app/assets/stylesheets`
* `app/assets/images`
* `app/components`

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] Your code contains tests relevant for code you modified
- [x] All new and existing tests are passing
- [x] You have linted the project with `bundle exec standardrb --fix`
- [x] You have linted the project with `bundle exec erblint --lint-all --autocorrect`
- [x] You have linted the project with `bundle exec i18n-tasks health`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
