### PR TITLE
Messaging moderation

### DIFF
--- a/app/assets/images/icons/outline/exclamation.svg
+++ b/app/assets/images/icons/outline/exclamation.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+</svg>

--- a/app/assets/images/icons/solid/flag.svg
+++ b/app/assets/images/icons/solid/flag.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clip-rule="evenodd" />
+</svg>

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -20,9 +20,9 @@ class BlocksController < ApplicationController
 
   def blocked_by_column
     if conversation.business?(current_user)
-      :blocked_by_business_at
+      :business_blocked_at
     elsif conversation.developer?(current_user)
-      :blocked_by_developer_at
+      :developer_blocked_at
     end
   end
 

--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -1,0 +1,32 @@
+class BlocksController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    authorize conversation, policy_class: MessagingPolicy
+    @conversation = conversation
+  end
+
+  def create
+    authorize conversation, policy_class: MessagingPolicy
+    conversation.touch(blocked_by_column)
+    redirect_to root_path, notice: t(".notice", other_recipient: other_recipient)
+  end
+
+  private
+
+  def conversation
+    @conversation ||= Conversation.find(params[:conversation_id])
+  end
+
+  def blocked_by_column
+    if conversation.business?(current_user)
+      :blocked_by_business_at
+    elsif conversation.developer?(current_user)
+      :blocked_by_developer_at
+    end
+  end
+
+  def other_recipient
+    conversation.other_recipient(current_user).hero
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,13 +16,13 @@ class MessagesController < ApplicationController
   private
 
   def conversation
-    Conversation.find(params[:conversation_id])
+    Conversation.visible.find(params[:conversation_id])
   end
 
   def sender
-    if conversation.business == current_user.business
+    if conversation.business?(current_user)
       current_user.business
-    elsif conversation.developer == current_user.developer
+    elsif conversation.developer?(current_user)
       current_user.developer
     end
   end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -2,7 +2,7 @@ class Business < ApplicationRecord
   include Avatarable
 
   belongs_to :user
-  has_many :conversations
+  has_many :conversations, -> { visible }
 
   validates :name, presence: true
   validates :company, presence: true

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,7 +6,21 @@ class Conversation < ApplicationRecord
 
   validates :developer_id, uniqueness: {scope: :business_id}
 
+  scope :visible, -> { where(blocked_by_developer_at: nil, blocked_by_business_at: nil) }
+
   def other_recipient(user)
     developer == user.developer ? business : developer
+  end
+
+  def business?(user)
+    business == user.business
+  end
+
+  def developer?(user)
+    developer == user.developer
+  end
+
+  def blocked?
+    blocked_by_developer_at.present? || blocked_by_business_at.present?
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,7 +6,7 @@ class Conversation < ApplicationRecord
 
   validates :developer_id, uniqueness: {scope: :business_id}
 
-  scope :visible, -> { where(blocked_by_developer_at: nil, blocked_by_business_at: nil) }
+  scope :visible, -> { where(developer_blocked_at: nil, business_blocked_at: nil) }
 
   def other_recipient(user)
     developer == user.developer ? business : developer
@@ -21,6 +21,6 @@ class Conversation < ApplicationRecord
   end
 
   def blocked?
-    blocked_by_developer_at.present? || blocked_by_business_at.present?
+    developer_blocked_at.present? || business_blocked_at.present?
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -9,7 +9,7 @@ class Developer < ApplicationRecord
   }
 
   belongs_to :user
-  has_many :conversations
+  has_many :conversations, -> { visible }
   has_one :role_type, dependent: :destroy, autosave: true
   has_one_attached :cover_image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
     unscope(where: :user_id)
       .left_joins(:business, :developer)
       .where("businesses.user_id = ? OR developers.user_id = ?", user.id, user.id)
+      .visible
   }
 
   scope :admin, -> { where(admin: true) }

--- a/app/policies/messaging_policy.rb
+++ b/app/policies/messaging_policy.rb
@@ -4,6 +4,16 @@ class MessagingPolicy < ApplicationPolicy
   end
 
   def create?
+    associated_with_record? && !blocked?
+  end
+
+  private
+
+  def associated_with_record?
     user.business == record.business || user.developer == record.developer
+  end
+
+  def blocked?
+    !!record.try(:blocked?)
   end
 end

--- a/app/views/blocks/new.html.erb
+++ b/app/views/blocks/new.html.erb
@@ -8,8 +8,8 @@
 
       <div class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
         <div class="sm:flex sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-            <%= inline_svg_tag "icons/outline/exclamation.svg", class: "h-6 w-6 text-red-600" %>
+          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
+            <%= inline_svg_tag "icons/outline/exclamation.svg", class: "h-6 w-6 text-gray-600" %>
           </div>
           <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
             <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">
@@ -21,7 +21,7 @@
           </div>
         </div>
         <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-          <%= button_to t(".block"), conversation_block_path(@conversation), method: :post, data: {turbo: false}, class: "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 hover:cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm" %>
+          <%= button_to t(".block"), conversation_block_path(@conversation), method: :post, data: {turbo: false}, class: "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-gray-600 text-base font-medium text-white hover:bg-gray-700 hover:cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:ml-3 sm:w-auto sm:text-sm" %>
           <%= link_to t(".cancel"), conversation_path(@conversation), data: {turbo: false}, class: "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm" %>
         </div>
       </div>

--- a/app/views/blocks/new.html.erb
+++ b/app/views/blocks/new.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+            <%= inline_svg_tag "icons/outline/exclamation.svg", class: "h-6 w-6 text-red-600" %>
+          </div>
+          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+              <%= t(".title") %>
+            </h3>
+            <div class="mt-2">
+              <p class="text-sm text-gray-500"><%= t(".message") %></p>
+            </div>
+          </div>
+        </div>
+        <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+          <%= button_to t(".block"), conversation_block_path(@conversation), method: :post, data: {turbo: false}, class: "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 hover:cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm" %>
+          <%= link_to t(".cancel"), conversation_path(@conversation), data: {turbo: false}, class: "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm" %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -1,23 +1,30 @@
 <%= render "shared/error_messages", resource: @message %>
 
-<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <h1 class="mt-6 text-center text-3xl">
-    <span class="font-extrabold"><%= t(".title") %></span>
+<div class="min-h-full max-w-2xl mx-auto py-12 sm:px-6 lg:px-8">
+  <div class="mt-6 flex items-start justify-between">
+    <h1 class="text-3xl px-6">
+      <span class="font-extrabold"><%= t(".title") %></span>
 
-    <div class="flex items-center justify-center space-x-2 mt-2 text-center text-sm text-gray-600">
-      <div class="block">with</div>
-      <%= link_to polymorphic_path(@conversation.other_recipient(current_user)), class: "flex items-center space-x-2 group" do %>
-        <%= render AvatarComponent.new(avatarable: @conversation.other_recipient(current_user), classes: "h-8 w-8") %>
-        <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @conversation.other_recipient(current_user).hero %></span>
-      <% end %>
-    </div>
-  </h1>
+      <div class="flex items-center space-x-2 mt-2 text-sm text-gray-600">
+        <div class="block"><%= t(".with") %></div>
+        <%= link_to polymorphic_path(@conversation.other_recipient(current_user)), class: "flex items-center space-x-2 group" do %>
+          <%= render AvatarComponent.new(avatarable: @conversation.other_recipient(current_user), classes: "h-8 w-8") %>
+          <span class="font-medium text-gray-600 group-hover:text-gray-500"><%= @conversation.other_recipient(current_user).hero %></span>
+        <% end %>
+      </div>
+    </h1>
 
-  <ul role="list" class="max-w-prose w-full mx-auto mt-8 space-y-2 sm:px-6 sm:space-y-4 lg:px-8">
+    <%= link_to new_conversation_block_path(@conversation), data: {"turbo-frame": "modal"}, class: "mt-2 mr-2 flex items-center text-gray-400 hover:text-gray-600" do %>
+      <span class="sr-only"><%= t(".flag") %></span>
+      <%= inline_svg_tag "icons/solid/flag.svg", class: "h-5 w-5" %>
+    <% end %>
+  </div>
+
+  <ul role="list" class="mt-8 space-y-2">
     <%= render @conversation.messages %>
   </ul>
 
-  <div class="mt-8 max-w-prose w-full mx-auto sm:px-6 lg:px-8">
+  <div class="mt-16 max-w-prose w-full mx-auto">
     <%= form_with model: [@conversation, @message], class: "relative" do |form| %>
       <%= render "messages/form", form: form %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,5 +27,6 @@
       <% end %>
     </div>
     <%= render "shared/footer" %>
+    <%= turbo_frame_tag "modal" %>
   </body>
 </html>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="border border-gray-300 rounded-lg shadow-sm overflow-hidden focus-within:border-gray-500 focus-within:ring-1 focus-within:ring-gray-500">
+<div class="border border-gray-300 sm:rounded-lg shadow-sm overflow-hidden focus-within:border-gray-500 focus-within:ring-1 focus-within:ring-gray-500">
   <%= form.label :body, t(".help"), class: "sr-only" %>
   <%= form.text_area :body, rows: 4, placeholder: t(".placeholder"), class: "block w-full py-3 border-0 resize-none focus:ring-0 sm:text-sm" %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,6 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
 
   # Watch additional directories for live reloading (outside of app/views, app/helpers, and app/javascript).
-  directories = %w[app/assets/stylesheets app/assets/images app/components]
+  directories = %w[app/assets/stylesheets app/assets/images app/components config/locales]
   config.hotwire_livereload.listen_paths += directories.map { |p| Rails.root.join(p) }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,14 @@ en:
     in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
     now_html: Available now
     unspecified_html: Currently unavailable
+  blocks:
+    create:
+      notice: "%{other_recipient} was blocked."
+    new:
+      block: Block
+      cancel: Cancel
+      message: Are you sure you want to flag this conversation and block the sender? This will hide the converation and they won't be able to contact you again.
+      title: Block sender
   businesses:
     create:
       created: Your business was added!
@@ -75,7 +83,9 @@ en:
     index:
       title: Your conversations
     show:
-      title: Conversations
+      flag: Flag this conversation
+      title: Conversation
+      with: with
   cover_image_component:
     alt: Developer's cover image
   developers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :businesses, except: :destroy
   resources :conversations, only: %i[index show] do
     resources :messages, only: :create
+    resource :block, only: %i[new create]
   end
 
   resources :developers, except: :destroy do

--- a/db/migrate/20211215034919_add_blocked_at_to_conversations.rb
+++ b/db/migrate/20211215034919_add_blocked_at_to_conversations.rb
@@ -1,0 +1,6 @@
+class AddBlockedAtToConversations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :blocked_by_developer_at, :datetime
+    add_column :conversations, :blocked_by_business_at, :datetime
+  end
+end

--- a/db/migrate/20211215034919_add_blocked_at_to_conversations.rb
+++ b/db/migrate/20211215034919_add_blocked_at_to_conversations.rb
@@ -1,6 +1,6 @@
 class AddBlockedAtToConversations < ActiveRecord::Migration[7.0]
   def change
-    add_column :conversations, :blocked_by_developer_at, :datetime
-    add_column :conversations, :blocked_by_business_at, :datetime
+    add_column :conversations, :developer_blocked_at, :datetime
+    add_column :conversations, :business_blocked_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_000002) do
+ActiveRecord::Schema.define(version: 2021_12_15_034919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,8 @@ ActiveRecord::Schema.define(version: 2021_12_14_000002) do
     t.bigint "business_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "blocked_by_developer_at", precision: 6
+    t.datetime "blocked_by_business_at", precision: 6
     t.index ["business_id"], name: "index_conversations_on_business_id"
     t.index ["developer_id"], name: "index_conversations_on_developer_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,8 +58,8 @@ ActiveRecord::Schema.define(version: 2021_12_15_034919) do
     t.bigint "business_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.datetime "blocked_by_developer_at", precision: 6
-    t.datetime "blocked_by_business_at", precision: 6
+    t.datetime "developer_blocked_at", precision: 6
+    t.datetime "business_blocked_at", precision: 6
     t.index ["business_id"], name: "index_conversations_on_business_id"
     t.index ["developer_id"], name: "index_conversations_on_developer_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,3 +39,10 @@ Developer.create!(
   github: "ada",
   twitter: "lovelace"
 )
+
+Business.create!(
+  user: create_user!("Business"),
+  name: "Thomas Dohmke",
+  company: "GitHub",
+  bio: "GitHub is where over 73 million developers shape the future of software, together."
+)

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -1,3 +1,8 @@
 one:
   developer: with_conversation
   business: with_conversation
+
+blocked:
+  developer: with_blocked_conversation
+  business: with_conversation
+  blocked_by_developer_at: <%= Time.now %>

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -5,4 +5,4 @@ one:
 blocked:
   developer: with_blocked_conversation
   business: with_conversation
-  blocked_by_developer_at: <%= Time.now %>
+  developer_blocked_at: <%= Time.now %>

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -17,3 +17,9 @@ with_conversation:
   name: Developer Three
   hero: Third developer
   bio: I am the third developer
+
+with_blocked_conversation:
+  user: with_blocked_conversation
+  name: Developer Four
+  hero: Fourth developer
+  bio: I am the fourth developer

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -30,6 +30,10 @@ with_business_conversation:
   email: business_conversation@example.com
   confirmed_at: <%= DateTime.current %>
 
+with_blocked_conversation:
+  email: blocked_conversation@example.com
+  confirmed_at: <%= DateTime.current %>
+
 admin:
   email: admin@example.com
   confirmed_at: <%= DateTime.current %>

--- a/test/integration/blocks_test.rb
+++ b/test/integration/blocks_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class BlocksTest < ActionDispatch::IntegrationTest
+  setup do
+    @developer = developers(:available)
+    @business = businesses(:one)
+    @conversation = Conversation.create!(developer: @developer, business: @business)
+  end
+
+  test "must be signed in" do
+    post conversation_block_path(@conversation)
+    assert_redirected_to new_user_registration_path
+  end
+
+  test "the developer can block the conversation" do
+    sign_in @developer.user
+
+    post conversation_block_path(@conversation)
+
+    assert_not_nil @conversation.reload.blocked_by_developer_at
+    assert_redirected_to root_path
+  end
+
+  test "the business can block the conversation" do
+    sign_in @business.user
+
+    post conversation_block_path(@conversation)
+
+    assert_not_nil @conversation.reload.blocked_by_business_at
+    assert_redirected_to root_path
+  end
+
+  test "no one else can contribute to the conversation" do
+    sign_in users(:empty)
+
+    post conversation_block_path(@conversation)
+
+    assert_nil @conversation.reload.blocked_by_developer_at
+    assert_nil @conversation.reload.blocked_by_business_at
+    assert_redirected_to root_path
+  end
+end

--- a/test/integration/blocks_test.rb
+++ b/test/integration/blocks_test.rb
@@ -17,7 +17,7 @@ class BlocksTest < ActionDispatch::IntegrationTest
 
     post conversation_block_path(@conversation)
 
-    assert_not_nil @conversation.reload.blocked_by_developer_at
+    assert_not_nil @conversation.reload.developer_blocked_at
     assert_redirected_to root_path
   end
 
@@ -26,7 +26,7 @@ class BlocksTest < ActionDispatch::IntegrationTest
 
     post conversation_block_path(@conversation)
 
-    assert_not_nil @conversation.reload.blocked_by_business_at
+    assert_not_nil @conversation.reload.business_blocked_at
     assert_redirected_to root_path
   end
 
@@ -35,8 +35,8 @@ class BlocksTest < ActionDispatch::IntegrationTest
 
     post conversation_block_path(@conversation)
 
-    assert_nil @conversation.reload.blocked_by_developer_at
-    assert_nil @conversation.reload.blocked_by_business_at
+    assert_nil @conversation.reload.developer_blocked_at
+    assert_nil @conversation.reload.business_blocked_at
     assert_redirected_to root_path
   end
 end

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -14,7 +14,7 @@ class MessagesTest < ActionDispatch::IntegrationTest
 
   test "can't view blocked conversations" do
     sign_in @developer.user
-    @conversation.touch(:blocked_by_developer_at)
+    @conversation.touch(:developer_blocked_at)
 
     assert_raises ActiveRecord::RecordNotFound do
       post conversation_messages_path(@conversation), params: message_params

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -2,14 +2,23 @@ require "test_helper"
 
 class MessagesTest < ActionDispatch::IntegrationTest
   setup do
-    @developer = developers(:available)
-    @business = businesses(:one)
-    @conversation = Conversation.create!(developer: @developer, business: @business)
+    @developer = developers(:with_conversation)
+    @business = businesses(:with_conversation)
+    @conversation = conversations(:one)
   end
 
   test "must be signed in" do
-    post developer_messages_path(@developer)
+    post conversation_messages_path(@conversation)
     assert_redirected_to new_user_registration_path
+  end
+
+  test "can't view blocked conversations" do
+    sign_in @developer.user
+    @conversation.touch(:blocked_by_developer_at)
+
+    assert_raises ActiveRecord::RecordNotFound do
+      post conversation_messages_path(@conversation), params: message_params
+    end
   end
 
   test "the developer in the conversation can continue the conversation" do

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -7,4 +7,11 @@ class BusinessTest < ActiveSupport::TestCase
       Business.create!(name: "name", company: "company", bio: "bio", user: user)
     end
   end
+
+  test "conversations relationship doesn't include blocked ones" do
+    business = businesses(:with_conversation)
+
+    assert business.conversations.include?(conversations(:one))
+    refute business.conversations.include?(conversations(:blocked))
+  end
 end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -1,6 +1,22 @@
 require "test_helper"
 
 class ConversationTest < ActiveSupport::TestCase
+  test "visible does not include ones blocked by the developer" do
+    conversation = conversations(:one)
+    assert Conversation.visible.include?(conversation)
+
+    conversation.touch(:blocked_by_developer_at)
+    refute Conversation.visible.include?(conversation)
+  end
+
+  test "visible does not include ones blocked by the business" do
+    conversation = conversations(:one)
+    assert Conversation.visible.include?(conversation)
+
+    conversation.touch(:blocked_by_business_at)
+    refute Conversation.visible.include?(conversation)
+  end
+
   test "other recipient is the business when the user is the developer" do
     user = users(:with_developer_conversation)
     conversation = conversations(:one)
@@ -11,5 +27,21 @@ class ConversationTest < ActiveSupport::TestCase
     user = users(:with_business_conversation)
     conversation = conversations(:one)
     assert_equal conversation.other_recipient(user), conversation.developer
+  end
+
+  test "is blocked if blocked by the developer" do
+    conversation = conversations(:one)
+    refute conversation.blocked?
+
+    conversation.touch(:blocked_by_developer_at)
+    assert conversation.blocked?
+  end
+
+  test "is blocked if blocked by the business" do
+    conversation = conversations(:one)
+    refute conversation.blocked?
+
+    conversation.touch(:blocked_by_business_at)
+    assert conversation.blocked?
   end
 end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -5,7 +5,7 @@ class ConversationTest < ActiveSupport::TestCase
     conversation = conversations(:one)
     assert Conversation.visible.include?(conversation)
 
-    conversation.touch(:blocked_by_developer_at)
+    conversation.touch(:developer_blocked_at)
     refute Conversation.visible.include?(conversation)
   end
 
@@ -13,7 +13,7 @@ class ConversationTest < ActiveSupport::TestCase
     conversation = conversations(:one)
     assert Conversation.visible.include?(conversation)
 
-    conversation.touch(:blocked_by_business_at)
+    conversation.touch(:business_blocked_at)
     refute Conversation.visible.include?(conversation)
   end
 
@@ -33,7 +33,7 @@ class ConversationTest < ActiveSupport::TestCase
     conversation = conversations(:one)
     refute conversation.blocked?
 
-    conversation.touch(:blocked_by_developer_at)
+    conversation.touch(:developer_blocked_at)
     assert conversation.blocked?
   end
 
@@ -41,7 +41,7 @@ class ConversationTest < ActiveSupport::TestCase
     conversation = conversations(:one)
     refute conversation.blocked?
 
-    conversation.touch(:blocked_by_business_at)
+    conversation.touch(:business_blocked_at)
     assert conversation.blocked?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,4 +10,10 @@ class UserTest < ActiveSupport::TestCase
     user = users(:with_business_conversation)
     assert_equal user.conversations, [conversations(:one)]
   end
+
+  test "blocked conversations are ignored" do
+    user = users(:with_business_conversation)
+    assert user.conversations.include?(conversations(:one))
+    refute user.conversations.include?(conversations(:blocked))
+  end
 end

--- a/test/policies/messaging_policy_test.rb
+++ b/test/policies/messaging_policy_test.rb
@@ -43,4 +43,24 @@ class MessagingPolicyTest < ActiveSupport::TestCase
 
     refute MessagingPolicy.new(user, conversation).show?
   end
+
+  test "no one can show or create a blocked conversation" do
+    user = users(:with_business)
+    developer = developers(:available)
+    business = user.business
+
+    conversation = Conversation.create!(developer: developer, business: business, blocked_by_developer_at: Time.now)
+
+    refute MessagingPolicy.new(user, conversation).show?
+    refute MessagingPolicy.new(user, conversation).create?
+  end
+
+  test "messages are never blocked" do
+    user = users(:with_business_conversation)
+
+    message = Message.create!(conversation: conversations(:one), sender: user.business, body: "Hi!")
+
+    assert MessagingPolicy.new(user, message).show?
+    assert MessagingPolicy.new(user, message).create?
+  end
 end

--- a/test/policies/messaging_policy_test.rb
+++ b/test/policies/messaging_policy_test.rb
@@ -49,7 +49,7 @@ class MessagingPolicyTest < ActiveSupport::TestCase
     developer = developers(:available)
     business = user.business
 
-    conversation = Conversation.create!(developer: developer, business: business, blocked_by_developer_at: Time.now)
+    conversation = Conversation.create!(developer: developer, business: business, developer_blocked_at: Time.now)
 
     refute MessagingPolicy.new(user, conversation).show?
     refute MessagingPolicy.new(user, conversation).create?


### PR DESCRIPTION
This PR is the first step towards messaging moderation. It enables developers and businesses to flag a conversation and block the sender.

Flagging and blocking are rolled into one, there is no difference. If you flag a conversation you block the sender (and visa versa) and are displayed in the UI as a single action.

In the database, two new columns were added to `Conversation`: `developer_blocked_at` and `business_blocked_at`. They start null, but if either are set then the conversation is considered "blocked" and neither party can see it anymore. These filters are done via the new `Conversation.visible` scope and `Conversation#blocked?` method.

This PR closes #148 and #149.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->