### PR TITLE
/admin/conversations to view blocked conversations

### DIFF
--- a/app/components/user_menu/signed_in_component.html.erb
+++ b/app/components/user_menu/signed_in_component.html.erb
@@ -12,6 +12,7 @@
       <%= render UserMenu::MenuItemComponent.new(t(".my_business_profile"), new_business_path, condition: business?) %>
       <%= render UserMenu::MenuItemComponent.new(t(".my_developer_profile"), new_developer_path, condition: developer?) %>
       <%= render UserMenu::MenuItemComponent.new(t(".my_conversations"), conversations_path, condition: conversations?) %>
+      <%= render UserMenu::MenuItemComponent.new(t(".admin"), admin_conversations_path, condition: admin?) %>
 
       <%= button_to t(".sign_out"), destroy_user_session_path, method: :delete, role: "menuitem", tabindex: "-1", data: {turbo: false}, class: "bg-transparent block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer w-full text-left" %>
     </div>

--- a/app/components/user_menu/signed_in_component.rb
+++ b/app/components/user_menu/signed_in_component.rb
@@ -20,4 +20,8 @@ class UserMenu::SignedInComponent < ApplicationComponent
   def conversations?
     (user.conversations.any? || business?) && Feature.enabled?(:messaging)
   end
+
+  def admin?
+    user.admin?
+  end
 end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,12 @@
+module Admin
+  class ApplicationController < ApplicationController
+    before_action :authenticate_user!
+    before_action :require_admin!
+
+    protected
+
+    def require_admin!
+      redirect_to root_path unless current_user.admin?
+    end
+  end
+end

--- a/app/controllers/admin/conversations_controller.rb
+++ b/app/controllers/admin/conversations_controller.rb
@@ -1,0 +1,7 @@
+module Admin
+  class ConversationsController < ApplicationController
+    def index
+      @conversations = Conversation.blocked
+    end
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,6 +6,7 @@ class Conversation < ApplicationRecord
 
   validates :developer_id, uniqueness: {scope: :business_id}
 
+  scope :blocked, -> { where.not(developer_blocked_at: nil).or(Conversation.where.not(business_blocked_at: nil)) }
   scope :visible, -> { where(developer_blocked_at: nil, business_blocked_at: nil) }
 
   def other_recipient(user)

--- a/app/views/admin/conversations/_conversation.html.erb
+++ b/app/views/admin/conversations/_conversation.html.erb
@@ -1,0 +1,14 @@
+<li class="relative bg-white py-5 px-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-blue-600">
+  <div class="flex justify-between space-x-3">
+    <div class="min-w-0 flex-1">
+      <p class="text-sm font-medium text-gray-900 truncate"><%= conversation.developer.hero %></p>
+      <p class="text-sm font-medium text-gray-900 truncate mt-2"><%= conversation.business.hero %></p>
+    </div>
+    <span class="flex-shrink-0 whitespace-nowrap text-sm text-gray-500">
+      <%= t(".blocked") %> <%= render TimeComponent.new(conversation.developer_blocked_at || conversation.business_blocked_at) %>
+    </span>
+  </div>
+  <div class="mt-4">
+    <p class="line-clamp-2 text-sm text-gray-600"><%= conversation.messages.last.body %></p>
+  </div>
+</li>

--- a/app/views/admin/conversations/_empty_state.html.erb
+++ b/app/views/admin/conversations/_empty_state.html.erb
@@ -1,0 +1,4 @@
+<div class="text-center">
+  <%= inline_svg_tag "icons/outline/inbox.svg", class: "mx-auto h-12 w-12 text-gray-400" %>
+  <h3 class="mt-2 text-sm font-medium text-gray-900"><%= t(".title") %></h3>
+</div>

--- a/app/views/admin/conversations/index.html.erb
+++ b/app/views/admin/conversations/index.html.erb
@@ -1,0 +1,13 @@
+<div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <% if @conversations.any? %>
+    <h1 class="mt-6 text-center text-3xl font-extrabold"><%= t(".title") %></h1>
+
+    <ul role="list" class="w-full max-w-xl mx-auto rounded-lg overflow-hidden border border-gray-200 divide-y divide-gray-200 mt-8">
+      <%= render @conversations %>
+    </ul>
+  <% else %>
+    <div class="mt-8">
+      <%= render "empty_state" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,14 @@ en:
       user:
         one: User
         other: Users
+  admin:
+    conversations:
+      conversation:
+        blocked: Blocked
+      empty_state:
+        title: No blocked conversations
+      index:
+        title: Blocked conversations
   availability_component:
     in_future_html: Available in <time datetime="%{date}">%{date_in_words}</time>
     now_html: Available now
@@ -182,6 +190,7 @@ en:
       open_source: Open source
   user_menu:
     signed_in_component:
+      admin: Admin
       get_started: Get started
       my_business_profile: My business profile
       my_conversations: My conversations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,12 @@ Rails.application.routes.draw do
     resources :messages, only: :create
     resource :block, only: %i[new create]
   end
-
   resources :developers, except: :destroy do
     resources :messages, only: %i[new create], controller: :cold_messages
+  end
+
+  namespace :admin do
+    resources :conversations, only: :index
   end
 
   root to: "home#show"

--- a/test/components/user_menu/signed_in_component_test.rb
+++ b/test/components/user_menu/signed_in_component_test.rb
@@ -50,6 +50,16 @@ class UserMenu::SignedInComponentTest < ViewComponent::TestCase
     assert_link_to conversations_path
   end
 
+  test "links to blocked conversations if user is an admin" do
+    user = users(:admin)
+    render_inline UserMenu::SignedInComponent.new(user)
+    assert_link_to admin_conversations_path
+
+    user = users(:with_business)
+    render_inline UserMenu::SignedInComponent.new(user)
+    assert_no_link_to admin_conversations_path
+  end
+
   def assert_link_to(path)
     assert_selector "a[href='#{path}']"
   end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -7,3 +7,8 @@ from_developer:
   conversation: one
   body: Two message.
   sender: with_conversation (Developer)
+
+blocked:
+  conversation: blocked
+  body: This message caused a block.
+  sender: with_conversation (Business)

--- a/test/integration/admin/blocked_conversations_test.rb
+++ b/test/integration/admin/blocked_conversations_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Admin::BlockedConversationsTest < ActionDispatch::IntegrationTest
+  test "must be signed in" do
+    get admin_conversations_path
+    assert_redirected_to new_user_registration_path
+  end
+
+  test "must be an admin" do
+    sign_in users(:empty)
+    get admin_conversations_path
+    assert_redirected_to root_path
+  end
+
+  test "shows only blocked conversations" do
+    sign_in users(:admin)
+
+    get admin_conversations_path
+
+    assert_select "p", text: developers(:with_blocked_conversation).hero
+    assert_select "p", text: developers(:with_conversation).hero, count: 0
+  end
+end


### PR DESCRIPTION
This PR closes #150 with an admin screen, `/admin/conversations`, to list blocked conversations. There's no actions to take but it serves as valuable information in seeing what and who is getting blocked/flagged.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
