### PR TITLE
Add additional stripe instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,23 @@ bin/dev
 
 ### Stripe
 
-If you are working on anything related to payments then you will need to configure Stripe.
+You may need to configure Stripe or do a mock configuration (ie set dummy values for the last step listed below) in order to get the development server to launch. If you are working on anything related to payments then you will need to fully configure Stripe.
 
 1. [Register for Stripe](https://dashboard.stripe.com/register) and add an account
+1. Download the Stripe CLI via `brew install stripe/stripe-cli/stripe`
 1. Login to the Stripe CLI via `stripe login`
 1. Configure your development credentials
-    1. Generate your credentials file via `bin/rails credentials:edit --environment development`
     1. [Create a Stripe secret key for test mode](https://dashboard.stripe.com/test/apikeys)
+    1. Run `stripe listen --forward-to localhost:3000/pay/webhooks/stripe` in order to generate your webhook signing secret.
     1. [Create a product](https://dashboard.stripe.com/test/products/create) with a recurring, monthly price
-    1. Add the secret key, the price, and your webhook signing secret to your development credentials in the following format:
+    1. Generate your editable development credentials file via `EDITOR="mate --wait" bin/rails credentials:edit --environment development`. You may need to install and provide terminal access to the editor first (mate, subl, and atom should all work). If you run the code above and receive the message "New credentials encrypted and saved", without having had the opportunity to edit the file first, things have gone astray. You will need to troubleshoot this step based on your OS and desired editor, to ensure you are able to edit the development.yml file before it is encoded and saved. [See here for more details.](https://stackoverflow.com/questions/52370065/issue-to-open-credentials-file)
+    1. Add the secret key, the price, and your webhook signing secret to your development credentials in the following format, and save/close the file:
 
 ```
 stripe:
   private_key: sk_test_YOUR_TEST_STRIPE_KEY
   signing_secret: whsec_YOUR_SIGNING_SECRET
-  price_id: price_YOUR_PRICE_ID
+  price_id: price_YOUR_PRODUCT_PRICE_ID
 ```
 
 ## Testing


### PR DESCRIPTION
Added additional details to the Stripe section of the readme to help junior contributors who are just setting up their credentials for the first time.

### Pull request checklist
- [X] Your code contains tests relevant for code you modified
- [X] You have linted and tested the project with `bin/check`
