### PR TITLE
Show CTA for paywalled content

### DIFF
--- a/app/assets/images/icons/outline/lock_closed.svg
+++ b/app/assets/images/icons/outline/lock_closed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+</svg>

--- a/app/assets/images/icons/outline/lock_open.svg
+++ b/app/assets/images/icons/outline/lock_open.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+</svg>

--- a/app/assets/images/icons/solid/lock_closed.svg
+++ b/app/assets/images/icons/solid/lock_closed.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd" />
+</svg>

--- a/app/assets/images/icons/solid/lock_open.svg
+++ b/app/assets/images/icons/solid/lock_open.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path d="M10 2a5 5 0 00-5 5v2a2 2 0 00-2 2v5a2 2 0 002 2h10a2 2 0 002-2v-5a2 2 0 00-2-2H7V7a3 3 0 015.905-.75 1 1 0 001.937-.5A5.002 5.002 0 0010 2z" />
+</svg>

--- a/app/components/paywalled_component.html.erb
+++ b/app/components/paywalled_component.html.erb
@@ -1,1 +1,18 @@
-<%= content %>
+<% if render_content? %>
+  <%= content %>
+<% elsif small? %>
+  <%= link_to pricing_path, class: "group flex items-center bg-gray-50 max-w-sm border border-gray-300 hover:border-gray-400 border-dashed rounded-lg mt-2 p-1.5 px-2.5" do %>
+    <%= inline_svg_tag "icons/solid/lock_closed.svg", class: "h-4 w-4 text-gray-400 mr-2 group-hover:hidden" %>
+    <%= inline_svg_tag "icons/solid/lock_open.svg", class: "h-4 w-4 text-gray-500 mr-2 rotate-[-8deg] transition hidden group-hover:block" %>
+    <span class="block text-xs font-medium text-gray-600"><%= t(".title") %></span>
+  <% end %>
+<% elsif large? %>
+  <div class="pt-4">
+    <%= link_to pricing_path, class: "block group bg-gray-50 w-full border-2 border-gray-300 hover:border-gray-400 border-dashed rounded-lg py-6 px-10 text-center" do %>
+      <%= inline_svg_tag "icons/outline/lock_closed.svg", class: "mx-auto h-8 w-8 text-gray-400 group-hover:hidden" %>
+      <%= inline_svg_tag "icons/outline/lock_open.svg", class: "mx-auto h-8 w-8 text-gray-600 rotate-[-8deg] transition hidden group-hover:block" %>
+      <span class="mt-2 block text-sm font-medium text-gray-600"><%= t(".title") %></span>
+      <span class="mt-2 block text-sm text-gray-500"><%= t(".description") %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/paywalled_component.rb
+++ b/app/components/paywalled_component.rb
@@ -1,11 +1,20 @@
 class PaywalledComponent < ApplicationComponent
-  def initialize(user:, paywalled:)
+  def initialize(user:, paywalled:, size: nil)
     @user = user
     @paywalled = paywalled
+    @size = size
   end
 
-  def render?
+  def render_content?
     customer? || owner?
+  end
+
+  def small?
+    @size == :small
+  end
+
+  def large?
+    @size == :large
   end
 
   private

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -12,7 +12,7 @@
     <%= render PreferredCompensationComponent.new(developer) %>
   <% end %>
 
-  <%= render PaywalledComponent.new(user: current_user, paywalled: developer) do %>
+  <%= render PaywalledComponent.new(user: current_user, paywalled: developer, size: :large) do %>
     <%= render RenderableComponent.new("space-y-3 pt-4") do %>
       <%= render ExternalLinkComponent.new(developer.website) %>
       <%= render SocialLinkComponent.new(developer.github, :github) %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -28,7 +28,7 @@
                   <% end %>
                 </div>
 
-                <%= link_to new_developer_message_path(@developer), rel: "nofollow", class: "shrink-0 mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+                <%= link_to new_developer_message_path(@developer), rel: "nofollow", class: "shrink-0 mt-8 md:mt-0 inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
                   <%= inline_svg_tag "icons/solid/briefcase.svg", class: "-ml-1 mr-3 h-5 w-5" %>
                   <%= t(".hire") %>
                 <% end %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -17,10 +17,10 @@
         <div class="lg:col-span-2 lg:pr-8 lg:border-r lg:border-gray-200">
           <div>
             <div>
-              <div class="md:flex md:items-center md:justify-between md:space-x-4 lg:border-b lg:pb-6">
-                <div>
+              <div class="md:flex md:items-start md:justify-between md:space-x-4 lg:border-b lg:pb-6">
+                <div class="w-full">
                   <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
-                  <%= render PaywalledComponent.new(user: current_user, paywalled: @developer) do %>
+                  <%= render PaywalledComponent.new(user: current_user, paywalled: @developer, size: :small) do %>
                     <div class="mt-2 flex items-center text-sm font-medium text-gray-500">
                       <%= inline_svg_tag "icons/solid/user.svg", class: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400" %>
                       <%= @developer.name %>

--- a/app/views/pricing/show.html.erb
+++ b/app/views/pricing/show.html.erb
@@ -17,8 +17,8 @@
     <div class="mt-4 sm:mt-8 md:mt-10 md:grid md:grid-cols-2 md:gap-x-8 xl:mt-0 xl:col-span-2">
       <ul role="list" class="divide-y divide-gray-200">
         <li class="py-4 flex md:py-0 md:pb-4">
-          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
-          <span class="ml-3 text-base text-gray-500"><%= t(".feature.1") %></span>
+          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-700" %>
+          <span class="ml-3 text-base text-gray-500 font-bold"><%= t(".feature.1") %></span>
         </li>
 
         <li class="py-4 flex">
@@ -30,21 +30,34 @@
           <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
           <span class="ml-3 text-base text-gray-500"><%= t(".feature.3") %></span>
         </li>
-      </ul>
-      <ul role="list" class="border-t border-gray-200 divide-y divide-gray-200 md:border-t-0">
-        <li class="py-4 flex md:border-t-0 md:py-0 md:pb-4">
-          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
-          <span class="ml-3 text-base text-gray-500"><%= t(".feature.4") %></span>
-        </li>
 
         <li class="py-4 flex">
           <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
-          <span class="ml-3 text-base text-gray-500"><%= t(".feature.5") %></span>
+          <span class="ml-3 text-base text-gray-500"><%= t(".feature.4") %></span>
+        </li>
+      </ul>
+      <ul role="list" class="border-t border-gray-200 divide-y divide-gray-200 md:border-t-0">
+        <li class="py-4 flex md:border-t-0 md:py-0 md:pb-4">
+          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-700" %>
+          <span class="ml-3 text-base text-gray-500 font-bold"><%= t(".feature.5") %></span>
         </li>
 
         <li class="py-4 flex">
           <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
           <span class="ml-3 text-base text-gray-500"><%= t(".feature.6") %></span>
+        </li>
+
+        <li class="py-4 flex">
+          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
+          <span class="ml-3 text-base text-gray-500"><%= t(".feature.7") %></span>
+        </li>
+
+        <li class="py-4 flex">
+          <%= inline_svg_tag "icons/outline/check.svg", class: "shrink-0 h-6 w-6 text-gray-500" %>
+          <%= link_to "https://github.com/joemasilotti/railsdevs.com", class: "ml-3 text-base text-gray-500 group" do %>
+            <span class="group-hover:underline"><%= t(".feature.8") %></span>
+            <span aria-hidden="true">&rarr;</span>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,9 @@ en:
       notice: Notification marked as read.
   open_graph_tags_component:
     default_description: Find Ruby on Rails developers looking for freelance, contract, and full-time work.
+  paywalled_component:
+    description: Information that is only visible with a business subscription.
+    title: Private information
   preferred_compensation_component:
     preferred_compensation: Preferred compensation
   pricing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,12 +203,14 @@ en:
           q: Who can I contact for more specific questions?
         title: Frequently asked questions
       feature:
-        '1': Support independent developers.
-        '2': Browse highly targeted profiles.
+        '1': Browse highly targeted profiles.
+        '2': Support independent developers.
         '3': Skip job descriptions and formal postings.
         '4': Talk directly to candidates.
-        '5': Hire as much or as little as you need.
-        '6': Cancel anytime with no obligations.
+        '5': Unlock private developer information.
+        '6': Hire as much or as little as you need.
+        '7': Cancel anytime with no obligations.
+        '8': Support open source development.
         subtitle: Browse developer profiles who can start working ASAP or when you need help. Save time by reaching out the perfect candidates.
         title: Hire at your own pace
       subtitle: Connect with independent, freelance Ruby on Rails developers who are available for work now.

--- a/test/components/paywalled_component_test.rb
+++ b/test/components/paywalled_component_test.rb
@@ -15,7 +15,7 @@ class PaywalledComponentTest < ViewComponent::TestCase
     assert_no_text "Test text"
   end
 
-  test "should should show paywall content to customers" do
+  test "should show paywall content to customers" do
     user = users(:with_business_conversation)
     developer = developers(:available)
     render_inline(PaywalledComponent.new(user: user, paywalled: developer)) { "Test text" }
@@ -29,5 +29,23 @@ class PaywalledComponentTest < ViewComponent::TestCase
     render_inline(PaywalledComponent.new(user: user, paywalled: developer)) { "Test text" }
 
     assert_text "Test text"
+  end
+
+  test "should show small CTA if paywalled" do
+    user = users(:with_business)
+    developer = developers(:available)
+
+    render_inline(PaywalledComponent.new(user: user, paywalled: developer, size: :small)) { "Test text" }
+    assert_text I18n.t("paywalled_component.title")
+    assert_no_text I18n.t("paywalled_component.description")
+  end
+
+  test "should show large CTA if paywalled" do
+    user = users(:with_business)
+    developer = developers(:available)
+
+    render_inline(PaywalledComponent.new(user: user, paywalled: developer, size: :large)) { "Test text" }
+    assert_text I18n.t("paywalled_component.title")
+    assert_text I18n.t("paywalled_component.description")
   end
 end


### PR DESCRIPTION
This PR adds a CTA in place of paywalled content to encourage businesses to sign up for a paid subscription. The wells link to the pricing page which describes that a business subscription unlocks hidden content.

This PR builds off of @jacobdaddario's #193, merged in earlier today.

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/2092156/147898780-859d5c3c-13c5-4d5f-9dcb-1bf200901120.png">
 
### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
