### PR TITLE
Fix: the Date.today usages in test cases

### DIFF
--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -13,21 +13,21 @@ class DeveloperTest < ActiveSupport::TestCase
   end
 
   test "available in a future date" do
-    @developer.available_on = Date.today + 2.weeks
+    @developer.available_on = Date.current + 2.weeks
 
     assert_equal "in_future", @developer.availability_status
     assert @developer.available_in_future?
   end
 
   test "available from a past date" do
-    @developer.available_on = Date.today - 3.weeks
+    @developer.available_on = Date.current - 3.weeks
 
     assert_equal "now", @developer.availability_status
     assert @developer.available_now?
   end
 
   test "available from today" do
-    @developer.available_on = Date.today
+    @developer.available_on = Date.current
 
     assert_equal "now", @developer.availability_status
     assert @developer.available_now?


### PR DESCRIPTION
Hi! This PR fixes a really small issue about the `Date.today` usages in test cases.

`Date.today.future?` will return `true` when it's midnight here (GMT +8), since it's based on the machine timezone.
I replaced them with `Date.current` so that these tests will not fail depends on machine settings.

<!-- Description of pull request linking to any relevant issues. -->

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
