### PR TITLE
Developer filters - hourly rate, salary, and time zone

### DIFF
--- a/app/assets/stylesheets/components/pagy.css
+++ b/app/assets/stylesheets/components/pagy.css
@@ -1,5 +1,5 @@
 .pagy-nav {
-  @apply flex space-x-2 mb-8 justify-center;
+  @apply flex space-x-2 my-8 justify-center;
 }
 
 .pagy-nav .page a,

--- a/app/components/developer_query_component.html.erb
+++ b/app/components/developer_query_component.html.erb
@@ -19,6 +19,91 @@
             </div>
           </div>
         </div>
+
+        <div class="hidden sm:flex sm:items-baseline sm:space-x-8">
+          <div data-controller="toggle" data-toggle-close-class="hidden" class="relative z-10 inline-block text-left">
+            <div>
+              <button type="button" data-action="toggle#toggle" class="group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900" aria-expanded="false">
+                <span><%= t(".budget.title") %></span>
+                <%= inline_svg_tag "icons/solid/chevron_down.svg", class: "flex-shrink-0 -mr-1 ml-1 h-5 w-5 text-gray-400 group-hover:text-gray-500" %>
+              </button>
+            </div>
+
+            <div data-toggle-target="element" class="w-44 origin-top-right absolute right-0 mt-2 bg-white rounded-md shadow-2xl p-4 ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <div class="space-y-4">
+                <div>
+                  <%= form.label :hourly_rate, t(".budget.hourly"), class: "block text-sm font-medium text-gray-700" %>
+                  <div class="mt-1 relative rounded-md shadow-sm">
+                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                      <span class="text-gray-500 sm:text-sm">
+                        $
+                      </span>
+                    </div>
+                    <%= form.text_field :hourly_rate, value: hourly_rate, autocomplete: "off", placeholder: "0", class: "focus:ring-gray-500 focus:border-gray-500 block w-full pl-7 pr-12 sm:text-sm border-gray-300 rounded-md" %>
+                    <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                      <span class="text-gray-500 sm:text-sm" id="price-currency">
+                        <%= t(".budget.per_hour") %>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <%= form.label :salary, t(".budget.salary"), class: "block text-sm font-medium text-gray-700" %>
+                  <div class="mt-1 relative rounded-md shadow-sm">
+                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                      <span class="text-gray-500 sm:text-sm">
+                        $
+                      </span>
+                    </div>
+                    <%= form.text_field :salary, value: salary, autocomplete: "off", placeholder: "0", class: "focus:ring-gray-500 focus:border-gray-500 block w-full pl-7 pr-12 sm:text-sm border-gray-300 rounded-md" %>
+                    <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                      <span class="text-gray-500 sm:text-sm" id="price-currency">
+                        <%= t(".budget.currency") %>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="pt-5">
+                <div class="flex justify-end">
+                  <button type="submit" class="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                    <%= t(".apply") %>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div data-controller="toggle" data-toggle-close-class="hidden" class="relative z-10 inline-block text-left">
+            <div>
+              <button type="button" data-action="toggle#toggle" class="group inline-flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-900" aria-expanded="false">
+                <span><%= t(".timezone.title") %></span>
+                <%= inline_svg_tag "icons/solid/chevron_down.svg", class: "flex-shrink-0 -mr-1 ml-1 h-5 w-5 text-gray-400 group-hover:text-gray-500" %>
+              </button>
+            </div>
+
+            <div data-toggle-target="element" class="origin-top-right absolute right-0 mt-2 bg-white rounded-md shadow-2xl p-4 ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <div class="space-y-4">
+                <%= form.collection_check_boxes(:time_zones, time_zones, :first, :last) do |b| %>
+                  <div class="flex items-center">
+                    <%= b.check_box class: "h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500", checked: selected?(b.object) %>
+                    <%= b.label class: "ml-3 pr-6 text-sm font-medium text-gray-900 whitespace-nowrap" %>
+                  </div>
+                <% end %>
+              </div>
+
+              <div class="pt-5">
+                <div class="flex justify-end">
+                  <button type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                    <%= t(".apply") %>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/components/developer_query_component.rb
+++ b/app/components/developer_query_component.rb
@@ -1,11 +1,29 @@
 class DeveloperQueryComponent < ApplicationComponent
   attr_reader :query
 
+  delegate :sort, to: :query
+  delegate :hourly_rate, to: :query
+  delegate :salary, to: :query
+
   def initialize(query)
     @query = query
   end
 
-  def sort
-    query.sort
+  def selected?(time_zone_pair)
+    query.time_zones.include?(time_zone_pair.first)
+  end
+
+  def time_zones
+    @time_zones ||= Developer.where.not(time_zone: [nil, ""])
+      .map { |d| formatted_time_zone(d.time_zone) }
+      .uniq.sort
+      .map { |offset| [offset, "#{offset} #{t("developer_query_component.gmt")}"] }
+  end
+
+  private
+
+  def formatted_time_zone(time_zone)
+    utc_offset = ActiveSupport::TimeZone.new(time_zone).utc_offset.fdiv(SECONDS_IN_AN_HOUR)
+    number_with_precision(utc_offset, precision: 1, strip_insignificant_zeros: true)
   end
 end

--- a/app/components/pagy_paginator_component/pagy_paginator_component.html.erb
+++ b/app/components/pagy_paginator_component/pagy_paginator_component.html.erb
@@ -2,11 +2,9 @@
   <%= content %>
 <% end %>
 
-<div class="mt-8">
-  <%= pagy_links do %>
-    <%== pagy_nav pagy %>
-  <% end %>
-</div>
+<%= pagy_links do %>
+  <%== pagy_nav pagy %>
+<% end %>
 
 <%= tag.turbo_frame id: "#{id}-#{pagy.page}" do %>
   <%= tag.turbo_stream target: id, action: "append" do %>

--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -2,6 +2,6 @@ module PagyHelper
   include Pagy::Frontend
 
   def pagy_links(**args, &block)
-    tag.div(id: "pagy-links", **args, data: {controller: "toggle", toggle_close_class: "invisible", toggle_target: "element"}, &block)
+    tag.div(id: "pagy-links", **args, data: {controller: "toggle", toggle_close_class: "hidden", toggle_target: "element"}, &block)
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -23,6 +23,10 @@ class Developer < ApplicationRecord
   validates :preferred_max_hourly_rate, allow_nil: true, numericality: {greater_than_or_equal_to: :preferred_min_hourly_rate}, if: -> { preferred_min_hourly_rate.present? }
   validates :preferred_max_salary, allow_nil: true, numericality: {greater_than_or_equal_to: :preferred_min_salary}, if: -> { preferred_min_salary.present? }
 
+  scope :filter_by_utc_offset, ->(utc_offset) { where(utc_offset: utc_offset) }
+  scope :filter_by_hourly_rate, ->(hourly_rate) { where("preferred_min_hourly_rate <= ?", hourly_rate) }
+  scope :filter_by_salary, ->(salary) { where("preferred_min_salary <= ?", salary) }
+
   scope :available, -> { where("available_on <= ?", Date.today) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :available_first, -> { where.not(available_on: nil).order(:available_on) }

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -24,10 +24,10 @@ class Developer < ApplicationRecord
   validates :preferred_max_salary, allow_nil: true, numericality: {greater_than_or_equal_to: :preferred_min_salary}, if: -> { preferred_min_salary.present? }
 
   scope :filter_by_utc_offset, ->(utc_offset) { where(utc_offset: utc_offset) }
-  scope :filter_by_hourly_rate, ->(hourly_rate) { where("preferred_min_hourly_rate <= ?", hourly_rate) }
-  scope :filter_by_salary, ->(salary) { where("preferred_min_salary <= ?", salary) }
+  scope :filter_by_hourly_rate, ->(hourly_rate) { where(preferred_min_hourly_rate: ..hourly_rate) }
+  scope :filter_by_salary, ->(salary) { where(preferred_min_salary: ..salary) }
 
-  scope :available, -> { where("available_on <= ?", Date.today) }
+  scope :available, -> { where(available_on: ..Time.current.to_date) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :available_first, -> { where.not(available_on: nil).order(:available_on) }
 

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -42,43 +42,37 @@ class DeveloperQuery
   private
 
   def initialize_pagy
-    records = Developer.includes(:role_type).with_attached_avatar
-    records = sorted(records)
-    records = time_zone_filtered(records)
-    records = hourly_rate_filtered(records)
-    records = salary_filtered(records)
-    @pagy, @records = build_pagy(records)
+    @_records = Developer.includes(:role_type).with_attached_avatar
+    sort_records
+    time_zone_filter_records
+    hourly_rate_filter_records
+    salary_filter_records
+    @pagy, @records = build_pagy(@_records)
   end
 
-  def sorted(records)
+  def sort_records
     if sort == :availability
-      records.merge(Developer.available_first)
+      @_records.merge!(Developer.available_first)
     else
-      records.merge(Developer.newest_first)
+      @_records.merge!(Developer.newest_first)
     end
   end
 
-  def time_zone_filtered(records)
+  def time_zone_filter_records
     if utc_offsets.any?
-      records.merge(Developer.filter_by_utc_offset(utc_offsets))
-    else
-      records
+      @_records.merge!(Developer.filter_by_utc_offset(utc_offsets))
     end
   end
 
-  def hourly_rate_filtered(records)
+  def hourly_rate_filter_records
     if hourly_rate.present?
-      records.merge(Developer.filter_by_hourly_rate(hourly_rate))
-    else
-      records
+      @_records.merge!(Developer.filter_by_hourly_rate(hourly_rate))
     end
   end
 
-  def salary_filtered(records)
+  def salary_filter_records
     if salary.present?
-      records.merge(Developer.filter_by_salary(salary))
-    else
-      records
+      @_records.merge!(Developer.filter_by_salary(salary))
     end
   end
 

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -8,6 +8,9 @@ class DeveloperQuery
   def initialize(options = {})
     @options = options
     @sort = options.delete(:sort)
+    @hourly_rate = options.delete(:hourly_rate)
+    @salary = options.delete(:salary)
+    @time_zones = options.delete(:time_zones)
   end
 
   def pagy
@@ -19,8 +22,21 @@ class DeveloperQuery
   end
 
   def sort
-    @sort = @sort.to_s.downcase.to_sym
-    @sort == :availability ? :availability : :newest
+    @sort.to_s.downcase.to_sym == :availability ? :availability : :newest
+  end
+
+  def hourly_rate
+    hourly_rate = @hourly_rate.to_i
+    hourly_rate > 0 ? hourly_rate : nil
+  end
+
+  def salary
+    salary = @salary.to_i
+    salary > 0 ? salary : nil
+  end
+
+  def time_zones
+    @time_zones.to_a.reject(&:blank?)
   end
 
   private
@@ -28,6 +44,9 @@ class DeveloperQuery
   def initialize_pagy
     records = Developer.includes(:role_type).with_attached_avatar
     records = sorted(records)
+    records = time_zone_filtered(records)
+    records = hourly_rate_filtered(records)
+    records = salary_filtered(records)
     @pagy, @records = build_pagy(records)
   end
 
@@ -37,6 +56,34 @@ class DeveloperQuery
     else
       records.merge(Developer.newest_first)
     end
+  end
+
+  def time_zone_filtered(records)
+    if utc_offsets.any?
+      records.merge(Developer.filter_by_utc_offset(utc_offsets))
+    else
+      records
+    end
+  end
+
+  def hourly_rate_filtered(records)
+    if hourly_rate.present?
+      records.merge(Developer.filter_by_hourly_rate(hourly_rate))
+    else
+      records
+    end
+  end
+
+  def salary_filtered(records)
+    if salary.present?
+      records.merge(Developer.filter_by_salary(salary))
+    else
+      records
+    end
+  end
+
+  def utc_offsets
+    time_zones.map { |tz| tz.to_f * SECONDS_IN_AN_HOUR }
   end
 
   # Needed for #pagy (aliased to #build_pagy) helper.

--- a/app/views/blocks/new.html.erb
+++ b/app/views/blocks/new.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
           <%= button_to t(".block"), conversation_block_path(@conversation), method: :post, data: {turbo: false}, class: "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-gray-600 text-base font-medium text-white hover:bg-gray-700 hover:cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:ml-3 sm:w-auto sm:text-sm" %>
-          <%= link_to t(".cancel"), conversation_path(@conversation), data: {turbo: false}, class: "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm" %>
+          <%= link_to t(".cancel"), conversation_path(@conversation), data: {turbo: false}, class: "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:mt-0 sm:w-auto sm:text-sm" %>
         </div>
       </div>
     </div>

--- a/app/views/businesses/show.html.erb
+++ b/app/views/businesses/show.html.erb
@@ -16,7 +16,7 @@
             </div>
             <div class="ml-4 lg:ml-0">
               <div class="text-base font-medium text-gray-900"><%= @business.company %></div>
-              <div class="text-base font-medium text-indigo-600"><%= @business.name %></div>
+              <div class="text-base font-medium text-gray-600"><%= @business.name %></div>
             </div>
           </div>
         </footer>

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -2,7 +2,7 @@
   <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
 <% end %>
 
-<div class="bg-white max-w-5xl mx-auto lg:mt-16 shadow overflow-hidden sm:rounded-md">
+<div class="bg-white max-w-5xl mx-auto lg:mt-16 mb-16 shadow overflow-auto sm:rounded-md">
   <div class="py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-4">
     <div>
       <h1 class="text-3xl font-extrabold tracking-tight text-gray-900"><%= t(".title") %></h1>
@@ -21,7 +21,9 @@
 
   <%= render PagyPaginatorComponent.new(id: "developers", pagy: @query.pagy, url_array: [:developers], container_classes: "divide-y divide-gray-200") do |component| %>
     <% component.loading_icon do %>
-      <%= render LoadingComponent.new %>
+      <div class="py-4">
+        <%= render LoadingComponent.new %>
+      </div>
     <% end %>
     <%= render DeveloperCardComponent.with_collection(@query.records) %>
   <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,10 +28,10 @@
 
         <div class="flex items-center justify-between">
           <% if devise_mapping.rememberable? %>
-          <div class="flex items-center">
-            <%= form.check_box :remember_me, class: "h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300 rounded" %>
-            <%= form.label :remember_me, class: "ml-2 block text-sm text-gray-900" %>
-          </div>
+            <div class="flex items-center">
+              <%= form.check_box :remember_me, class: "h-4 w-4 text-gray-600 focus:ring-gray-500 border-gray-300 rounded" %>
+              <%= form.label :remember_me, class: "ml-2 block text-sm text-gray-900" %>
+            </div>
           <% end %>
 
           <%= render "devise/shared/forgot_link" if devise_mapping.recoverable? %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,1 @@
+SECONDS_IN_AN_HOUR = 60 * 60

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,10 +97,20 @@ en:
   cover_image_component:
     alt: Developer's cover image
   developer_query_component:
+    apply: Apply
+    budget:
+      currency: USD
+      hourly: Max. hourly rate
+      per_hour: "/hr"
+      salary: Max. salary
+      title: Budget
+    gmt: GMT
     sort:
       availability: Availability
       newest: Newest
       title: Sort
+    timezone:
+      title: Timezone
     title: Developer filters
   developers:
     create:

--- a/db/migrate/20220108043339_add_utc_offset_to_developers.rb
+++ b/db/migrate/20220108043339_add_utc_offset_to_developers.rb
@@ -1,0 +1,5 @@
+class AddUtcOffsetToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :utc_offset, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_18_203645) do
+ActiveRecord::Schema.define(version: 2022_01_08_043339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 2021_12_18_203645) do
     t.integer "preferred_min_salary"
     t.integer "preferred_max_salary"
     t.string "time_zone"
+    t.integer "utc_offset"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/lib/tasks/developers.rake
+++ b/lib/tasks/developers.rake
@@ -1,0 +1,9 @@
+namespace :developers do
+  desc "Set developers.utc_offset for records with a time zone."
+  task utc_offset: :environment do
+    Developer.where.not(time_zone: [nil, ""]).find_each do |developer|
+      utc_offset = ActiveSupport::TimeZone.new(developer.time_zone).utc_offset
+      developer.update_column(:utc_offset, utc_offset) unless utc_offset == developer.utc_offset
+    end
+  end
+end

--- a/test/components/developer_query_component_test.rb
+++ b/test/components/developer_query_component_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class DeveloperQueryComponentTest < ViewComponent::TestCase
+  test "emphasises the selected sorting" do
+    query = DeveloperQuery.new(sort: :availability)
+    render_inline DeveloperQueryComponent.new(query)
+    assert_selector "button.text-gray-700", text: "Newest"
+    assert_selector "button.text-gray-900", text: "Availability"
+  end
+
+  test "populates budget input fields from query" do
+    query = DeveloperQuery.new(hourly_rate: 100, salary: 100_000)
+    render_inline DeveloperQueryComponent.new(query)
+    assert_selector "input[name=hourly_rate][value=100]"
+    assert_selector "input[name=salary][value=100000]"
+  end
+
+  test "renders unique UTC offset pairs for developers" do
+    query = DeveloperQuery.new({})
+    render_inline DeveloperQueryComponent.new(query)
+
+    assert_selector "input[type=checkbox][name='time_zones[]'][value=-5]"
+    assert_selector "input[type=checkbox][name='time_zones[]'][value=-8]"
+
+    assert_selector "label[for=time_zones_-5]", text: "-5 GMT"
+    assert_selector "label[for=time_zones_-8]", text: "-8 GMT"
+  end
+
+  test "checks selected timezones" do
+    query = DeveloperQuery.new(time_zones: ["-8"])
+    render_inline DeveloperQueryComponent.new(query)
+
+    assert_no_selector "input[checked][type=checkbox][name='time_zones[]'][value=-5]"
+    assert_selector "input[checked][type=checkbox][name='time_zones[]'][value=-8]"
+  end
+end

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -4,6 +4,12 @@ available:
   available_on: <%= Date.new(2021, 1, 1) %>
   hero: First developer
   bio: I am the first developer
+  preferred_min_hourly_rate: 100
+  preferred_max_hourly_rate: 150
+  preferred_min_salary: 100_000
+  preferred_max_salary: 150_000
+  time_zone: Eastern Time (US & Canada)
+  utc_offset: -18_000
 
 unavailable:
   user: with_unavailable_profile
@@ -11,6 +17,12 @@ unavailable:
   available_on: <%= Date.new(2222, 2, 2) %>
   hero: Second developer
   bio: I am the second developer
+  time_zone: Pacific Time (US & Canada)
+  utc_offset: -28_800
+  preferred_min_hourly_rate: 200
+  preferred_max_hourly_rate: 250
+  preferred_min_salary: 200_000
+  preferred_max_salary: 250_000
 
 with_conversation:
   user: with_developer_conversation

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -29,6 +29,30 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_select "h2", text: developers(:with_conversation).hero, count: 0
   end
 
+  test "developers can be filtered by max. hourly rate" do
+    get developers_path(hourly_rate: 125)
+
+    assert_select "input[type=text][value=125][name=hourly_rate]"
+    assert_select "h2", developers(:available).hero
+    assert_select "h2", text: developers(:unavailable).hero, count: 0
+  end
+
+  test "developers can be filtered by max. salary" do
+    get developers_path(salary: 125_000)
+
+    assert_select "input[type=text][value=125000][name=salary]"
+    assert_select "h2", developers(:available).hero
+    assert_select "h2", text: developers(:unavailable).hero, count: 0
+  end
+
+  test "developers can be filtered by time zone" do
+    get developers_path(time_zones: ["-8"])
+
+    assert_select "input[checked][type=checkbox][value=-8][name='time_zones[]']"
+    assert_select "h2", developers(:unavailable).hero
+    assert_select "h2", text: developers(:available).hero, count: 0
+  end
+
   test "cannot create new proflie if already has one" do
     sign_in users(:with_available_profile)
 

--- a/test/lib/tasks/developers_utc_offset_task_test.rb
+++ b/test/lib/tasks/developers_utc_offset_task_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class DevelopersUtcOffsetTaskTest < ActiveSupport::TestCase
+  test "sets developers.utc_offset for records with a time zone" do
+    Railsdevs::Application.load_tasks
+    Rake::Task["developers:utc_offset"].invoke
+
+    assert_equal(-18_000, developers(:available).utc_offset)
+    assert_equal(-28_800, developers(:unavailable).utc_offset)
+    assert_nil developers(:with_conversation).utc_offset
+  end
+end

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -28,6 +28,32 @@ class DeveloperQueryTest < ActiveSupport::TestCase
     ]
   end
 
+  test "filtering by hourly rate" do
+    records = DeveloperQuery.new(hourly_rate: 125).records
+    assert_equal records, [developers(:available)]
+  end
+
+  test "filtering by salary" do
+    records = DeveloperQuery.new(salary: 125_000).records
+    assert_equal records, [developers(:available)]
+  end
+
+  test "hourly rate and salary are nil if not greater than zero" do
+    assert_nil DeveloperQuery.new(hourly_rate: -1).hourly_rate
+    assert_nil DeveloperQuery.new(salary: -1).salary
+
+    assert_nil DeveloperQuery.new(hourly_rate: 0).hourly_rate
+    assert_nil DeveloperQuery.new(salary: 0).salary
+
+    assert_nil DeveloperQuery.new.hourly_rate
+    assert_nil DeveloperQuery.new.salary
+  end
+
+  test "filtering by time zones" do
+    records = DeveloperQuery.new(time_zones: ["-8"]).records
+    assert_equal records, [developers(:unavailable)]
+  end
+
   test "pagy is initialized without errors" do
     assert_not_nil DeveloperQuery.new.pagy
   end


### PR DESCRIPTION
This PR closes #203 by adding three filters: hourly rate, salary, and time zone. This build on the `DeveloperQuery` and `DeveloperQueryComponent` from #177.

Budget filtering (hourly rate and salary) is done by comparing to the developer's minimum preferred compensation.

To get time zone filtering to work the UTC offset of developer time zones needs to be persisted. This is backfill via `rake developers:utc_offset`. Because UTC offsets can change (like during daylight savings), this script will need to be run frequently. I've tried to make it as low friction and non-destructive as possible, so it should be safe to run every day.

[According to Wikipedia](https://en.wikipedia.org/wiki/Daylight_saving_time_by_country), there are a lot of different days and times when countries switch over to/from DST, so I don't want to try and get smart and only run this on specific dates/times.

### Pull request checklist

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

### Deployment checklist

- [x] Schedule a daily task to run `bundle exec rake developers:utc_offset` every day at 5am UTC
- [ ] Merge this PR