### PR TITLE
Require visit to `/pricing` before Stripe Checkout

### DIFF
--- a/app/controllers/cold_messages_controller.rb
+++ b/app/controllers/cold_messages_controller.rb
@@ -2,6 +2,7 @@ class ColdMessagesController < ApplicationController
   before_action :authenticate_user!
   before_action :require_business!
   before_action :require_new_conversation!
+  before_action :require_pricing_visit!
   before_action :require_active_subscription!
 
   def new
@@ -28,6 +29,10 @@ class ColdMessagesController < ApplicationController
 
   def require_new_conversation!
     redirect_to conversation unless conversation.new_record?
+  end
+
+  def require_pricing_visit!
+    redirect_to pricing_path(developer:) unless PricingVisit.new(session).visited?
   end
 
   def require_active_subscription!

--- a/app/controllers/pricing_controller.rb
+++ b/app/controllers/pricing_controller.rb
@@ -1,4 +1,13 @@
 class PricingController < ApplicationController
+  after_action :track_pricing_visit
+
   def show
+    @cta = stripe_checkout_path(developer: params[:developer])
+  end
+
+  private
+
+  def track_pricing_visit
+    PricingVisit.new(session).track_visit
   end
 end

--- a/app/controllers/stripe/checkouts_controller.rb
+++ b/app/controllers/stripe/checkouts_controller.rb
@@ -3,7 +3,8 @@ module Stripe
     before_action :authenticate_user!
 
     def show
-      redirect_to BusinessSubscriptionCheckout.new(current_user).url
+      developer = Developer.find_by(id: params[:developer])
+      redirect_to BusinessSubscriptionCheckout.new(current_user, developer:).url
     end
   end
 end

--- a/app/models/pricing_visit.rb
+++ b/app/models/pricing_visit.rb
@@ -1,0 +1,17 @@
+class PricingVisit
+  SESSION_KEY = "visits.pricing".freeze
+
+  attr_reader :session
+
+  def initialize(session)
+    @session = session
+  end
+
+  def track_visit
+    session[SESSION_KEY] = true
+  end
+
+  def visited?
+    ActiveModel::Type::Boolean.new.cast(session[SESSION_KEY])
+  end
+end

--- a/app/views/pricing/show.html.erb
+++ b/app/views/pricing/show.html.erb
@@ -7,7 +7,7 @@
       </h1>
       <p class="mt-5 text-xl text-gray-500"><%= t(".subtitle") %></p>
     </div>
-    <%= link_to t(".cta"), stripe_checkout_path, rel: "nofollow", class: "mt-8 w-full bg-gray-600 border border-transparent rounded-md py-3 px-5 inline-flex items-center justify-center text-base font-medium text-white hover:bg-gray-700 sm:mt-10 sm:w-auto xl:mt-0" %>
+    <%= link_to t(".cta"), @cta, rel: "nofollow", class: "mt-8 w-full bg-gray-600 border border-transparent rounded-md py-3 px-5 inline-flex items-center justify-center text-base font-medium text-white hover:bg-gray-700 sm:mt-10 sm:w-auto xl:mt-0" %>
   </div>
   <div class="border-t border-gray-200 pt-16 xl:grid xl:grid-cols-3 xl:gap-x-8">
     <div>

--- a/test/integration/cold_messages_test.rb
+++ b/test/integration/cold_messages_test.rb
@@ -23,8 +23,16 @@ class ColdMessagesTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_business_path
   end
 
+  test "must have visited /pricing this session" do
+    sign_in businesses(:one).user
+    get new_developer_message_path(@developer)
+    assert_redirected_to pricing_path(developer: @developer)
+  end
+
   test "must have an active business subscription" do
     sign_in businesses(:one).user
+    get pricing_path
+
     stub_pay(businesses(:one).user, expected_success_url: new_developer_message_url(@developer)) do
       get new_developer_message_path(@developer)
       assert_redirected_to "checkout.stripe.com"
@@ -33,12 +41,16 @@ class ColdMessagesTest < ActionDispatch::IntegrationTest
 
   test "a business can start a new conversation" do
     sign_in @business.user
+    get pricing_path
+
     get new_developer_message_path(@developer)
+
     assert_select "form[action=?]", developer_messages_path(@developer)
   end
 
   test "a business can create a new conversation" do
     sign_in @business.user
+    get pricing_path
 
     assert_difference "Message.count", 1 do
       assert_difference "Conversation.count", 1 do
@@ -62,6 +74,7 @@ class ColdMessagesTest < ActionDispatch::IntegrationTest
 
   test "an invalid message re-renders the form" do
     sign_in @business.user
+    get pricing_path
 
     assert_no_difference "Message.count" do
       assert_no_difference "Conversation.count" do

--- a/test/integration/pricing_test.rb
+++ b/test/integration/pricing_test.rb
@@ -6,4 +6,8 @@ class PricingTest < ActionDispatch::IntegrationTest
 
     assert_select "h1", text: /^Hire Rails developers/
   end
+
+  test "TODO: developer params test" do
+    assert false
+  end
 end

--- a/test/models/pricing_visit_test.rb
+++ b/test/models/pricing_visit_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class PricingVisitTest < ActiveSupport::TestCase
+  test "tracks a visit" do
+    session = {}
+
+    visit = PricingVisit.new(session)
+    refute visit.visited?
+
+    visit.track_visit
+    assert visit.visited?
+  end
+end


### PR DESCRIPTION
I have a hypothesis that potential customers are going through the cold message flow, getting dropped on a Stripe Checkout page, and dropping because they weren't educated on what they would be paying for.

This PR requires visiting `/pricing` at least once during the current Rails session before being redirected to check out. There are a few failing tests and a few placeholders. I'm not sure how scalable this solution is, but wanted to push my WIP while I work on other things.

### Pull request checklist

- [ ] Your code contains tests relevant for code you modified
- [ ] You have linted and tested the project with `bin/check`