### PR TITLE
Profile images do not keep attached on form error

### DIFF
--- a/app/views/businesses/_form.html.erb
+++ b/app/views/businesses/_form.html.erb
@@ -46,8 +46,8 @@
                     <%= inline_svg_tag "icons/outline/refresh.svg", class: "w-8 h-8 text-gray-900 animate-reverse-spin" %>
                   </div>
                 </div>
-                <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.hidden_field :avatar, value: form.object.avatar.signed_id, id: "business_avatar_hidden" if form.object.avatar.attached? %>
+                <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.label :avatar, t(".change_avatar"), class: "cursor-pointer ml-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
               </div>
               <div data-file-upload-target="error" class="hidden bg-red-50 border-l-4 border-red-400 p-4 mt-4">

--- a/app/views/businesses/_form.html.erb
+++ b/app/views/businesses/_form.html.erb
@@ -47,6 +47,7 @@
                   </div>
                 </div>
                 <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
+                <%= form.hidden_field :avatar, value: form.object.avatar.signed_id, id: "business_avatar_hidden" if form.object.avatar.attached? %>
                 <%= form.label :avatar, t(".change_avatar"), class: "cursor-pointer ml-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
               </div>
               <div data-file-upload-target="error" class="hidden bg-red-50 border-l-4 border-red-400 p-4 mt-4">

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -55,8 +55,8 @@
                     <%= inline_svg_tag "icons/outline/refresh.svg", class: "w-8 h-8 text-gray-900 animate-reverse-spin" %>
                   </div>
                 </div>
-                <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.hidden_field :avatar, value: form.object.avatar.signed_id, id: "developer_avatar_hidden" if form.object.avatar.attached? %>
+                <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.label :avatar, t(".profile.change"), class: "cursor-pointer ml-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
               </div>
               <div data-file-upload-target="error" class="hidden bg-red-50 border-l-4 border-red-400 p-4 mt-4">
@@ -69,9 +69,9 @@
             <div data-controller="file-upload" data-file-upload-visibility-class="hidden" data-file-upload-loading-class="opacity-50" class="sm:col-span-6">
               <span class="block text-sm font-medium text-gray-700"><%= t(".profile.cover_image") %></span>
               <div class="relative">
-                <%= form.file_field :cover_image, direct_upload: true, accept: "image/png, image/jpg, image/jpeg, image/gif", data: {action: "input->file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.label :cover_image, t(".profile.change"), class: "cursor-pointer absolute right-0 bottom-0 z-10 m-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
                 <%= form.hidden_field :cover_image, value: form.object.cover_image.signed_id, id: "developer_cover_image_hidden" if form.object.cover_image.attached? %>
+                <%= form.file_field :cover_image, direct_upload: true, accept: "image/png, image/jpg, image/jpeg, image/gif", data: {action: "input->file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
 
                 <%= render CoverImageComponent.new(developer: developer, data: {"file-upload-target": "image"}, classes: "rounded-md mb-4") %>
                 <div data-file-upload-target="activity" class="hidden absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -56,6 +56,7 @@
                   </div>
                 </div>
                 <%= form.file_field :avatar, direct_upload: true, accept: "image/png, image/jpg, image/jpeg", data: {action: "file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
+                <%= form.hidden_field :avatar, value: form.object.avatar.signed_id, id: "developer_avatar_hidden" if form.object.avatar.attached? %>
                 <%= form.label :avatar, t(".profile.change"), class: "cursor-pointer ml-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
               </div>
               <div data-file-upload-target="error" class="hidden bg-red-50 border-l-4 border-red-400 p-4 mt-4">
@@ -70,6 +71,7 @@
               <div class="relative">
                 <%= form.file_field :cover_image, direct_upload: true, accept: "image/png, image/jpg, image/jpeg, image/gif", data: {action: "input->file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
                 <%= form.label :cover_image, t(".profile.change"), class: "cursor-pointer absolute right-0 bottom-0 z-10 m-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+                <%= form.hidden_field :cover_image, value: form.object.cover_image.signed_id, id: "developer_cover_image_hidden" if form.object.cover_image.attached? %>
 
                 <%= render CoverImageComponent.new(developer: developer, data: {"file-upload-target": "image"}, classes: "rounded-md mb-4") %>
                 <div data-file-upload-target="activity" class="hidden absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -69,9 +69,9 @@
             <div data-controller="file-upload" data-file-upload-visibility-class="hidden" data-file-upload-loading-class="opacity-50" class="sm:col-span-6">
               <span class="block text-sm font-medium text-gray-700"><%= t(".profile.cover_image") %></span>
               <div class="relative">
-                <%= form.label :cover_image, t(".profile.change"), class: "cursor-pointer absolute right-0 bottom-0 z-10 m-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
                 <%= form.hidden_field :cover_image, value: form.object.cover_image.signed_id, id: "developer_cover_image_hidden" if form.object.cover_image.attached? %>
                 <%= form.file_field :cover_image, direct_upload: true, accept: "image/png, image/jpg, image/jpeg, image/gif", data: {action: "input->file-upload#select direct-upload:initialize->file-upload#start direct-upload:error->file-upload#error"}, class: "hidden" %>
+                <%= form.label :cover_image, t(".profile.change"), class: "cursor-pointer absolute right-0 bottom-0 z-10 m-5 bg-white py-2 px-3 border border-gray-300 rounded-md shadow-sm text-sm leading-4 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
 
                 <%= render CoverImageComponent.new(developer: developer, data: {"file-upload-target": "image"}, classes: "rounded-md mb-4") %>
                 <div data-file-upload-target="activity" class="hidden absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -15,3 +15,9 @@ three:
   record_type: Business
   record_id: <%= ActiveRecord::FixtureSet.identify(:with_conversation) %>
   blob_id: <%= ActiveRecord::FixtureSet.identify(:three) %>
+
+four:
+  name: avatar
+  record_type: Business
+  record_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  blob_id: <%= ActiveRecord::FixtureSet.identify(:three) %>

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -63,6 +63,7 @@ class BusinessesTest < ActionDispatch::IntegrationTest
 
     get edit_business_path(business)
     assert_select "form"
+    assert_select "#business_avatar_hidden"
 
     patch business_path(business), params: {
       business: {
@@ -93,6 +94,7 @@ class BusinessesTest < ActionDispatch::IntegrationTest
 
     get edit_business_path(business)
     assert_select "form"
+    assert_select "#business_avatar_hidden"
 
     patch business_path(business), params: {
       business: {

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -107,6 +107,8 @@ class DevelopersTest < ActionDispatch::IntegrationTest
 
     get edit_developer_path(developer)
     assert_select "form"
+    assert_select "#developer_avatar_hidden"
+    assert_select "#developer_cover_image_hidden"
 
     patch developer_path(developer), params: {
       developer: {
@@ -137,6 +139,8 @@ class DevelopersTest < ActionDispatch::IntegrationTest
 
     get edit_developer_path(developer)
     assert_select "form"
+    assert_select "#developer_avatar_hidden"
+    assert_select "#developer_cover_image_hidden"
 
     patch developer_path(developer), params: {
       developer: {


### PR DESCRIPTION
Fixes #249

When an image is uploaded on developer profile and some other field fails validation, the original image is not persisted across requests and fails do be properly set on second request.

This causes user to have to re-upload image and creates a set of phantom images on database (and potentially on storage as well).

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
