### PR TITLE
Add relative availability

### DIFF
--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -52,6 +52,7 @@ class DevelopersController < ApplicationController
     params.require(:developer).permit(
       :name,
       :available_on,
+      :available_in_days,
       :hero,
       :bio,
       :website,

--- a/app/javascript/controllers/clear_field_controller.js
+++ b/app/javascript/controllers/clear_field_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="clear-field"
+export default class extends Controller {
+  static values = {
+    target: String
+  }
+  connect() {
+    this.target = document.querySelector(this.targetValue)
+  }
+
+  clear() {
+    this.target.value = ""
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,9 @@
 
 import { application } from "./application"
 
+import ClearFieldController from "./clear_field_controller.js"
+application.register("clear-field", ClearFieldController)
+
 import FileUploadController from "./file_upload_controller.js"
 application.register("file-upload", FileUploadController)
 

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -7,13 +7,13 @@ module Availability
     after_initialize :derive_availability_status
   end
 
+  def available_in
+    available_in_days.days
+  end
+
   def available_in_days=(days)
     super(days&.to_i&.clamp(0..))
     derive_availability_status
-  end
-
-  def available_in_days
-    super&.days
   end
 
   def available_on

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -7,6 +7,19 @@ module Availability
     after_initialize :derive_availability_status
   end
 
+  def available_in_days=(days)
+    super(days&.clamp(0..))
+    derive_availability_status
+  end
+
+  def available_in_days
+    super&.days
+  end
+
+  def available_on
+    super || (available_in_days.present? ? Date.current + available_in_days : nil)
+  end
+
   def available_on=(date)
     super(date)
     derive_availability_status

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -8,7 +8,7 @@ module Availability
   end
 
   def available_in_days=(days)
-    super(days&.clamp(0..))
+    super(days&.to_i&.clamp(0..))
     derive_availability_status
   end
 

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -41,10 +41,6 @@ class Developer < ApplicationRecord
     super || build_role_type
   end
 
-  def available_in_days=(days)
-    super(days&.clamp(0..))
-  end
-
   private
 
   def send_admin_notification

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -41,6 +41,10 @@ class Developer < ApplicationRecord
     super || build_role_type
   end
 
+  def available_in_days=(days)
+    super(days&.clamp(0..))
+  end
+
   private
 
   def send_admin_notification

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -161,8 +161,24 @@
                 <div class="grid grid-cols-1 sm:grid-cols-3 sm:col-span-3 md:gap-6">
                   <div class="sm:col-span-1">
                     <%= form.label :available_on, class: "block text-sm font-medium text-gray-700" %>
-                    <div class="mt-1">
-                      <%= form.date_field :available_on, value: developer.available_on_in_database, class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center" %>
+                    <div class="mt-1 flex items-center w-full">
+                      <%= form.date_field :available_on, value: developer.available_on_in_database || '', class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center",
+                          data: {
+                            controller: 'clear-field',
+                            clear_field_target_value: 'input[name="developer[available_in_days]"]',
+                            action: 'input->clear-field#clear'
+                          }
+                      %>
+                      <%= button_tag 'Clear',
+                          name: 'clear_available_on',
+                          type: :button,
+                          class: "inline-flex justify-center align-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 cursor-pointer hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 ml-3",
+                          data: {
+                            controller: 'clear-field',
+                            clear_field_target_value: 'input[name="developer[available_on]"]',
+                            action: 'click->clear-field#clear'
+                          }
+                          %>
                     </div>
                   </div>
                 </div>
@@ -175,7 +191,13 @@
                   <div class="sm:col-span-1">
                     <%= form.label :available_in_days, class: "block text-sm font-medium text-gray-700" %>
                     <div class="mt-1 flex rounded-md shadow-sm">
-                      <%= form.number_field :available_in_days, class: "flex-1 focus:ring-gray-500 focus:border-gray-500 block w-full min-w-0 rounded-none rounded-l-md sm:text-sm border-gray-300 border-r-0" %>
+                      <%= form.number_field :available_in_days, value: developer.available_on_in_database.present? ? nil : developer.available_in_days_in_database, class: "flex-1 focus:ring-gray-500 focus:border-gray-500 block w-full min-w-0 rounded-none rounded-l-md sm:text-sm border-gray-300 border-r-0",
+                          data: {
+                            controller: 'clear-field',
+                            clear_field_target_value: 'input[name="developer[available_on]"]',
+                            action: 'input->clear-field#clear'
+                          }
+                      %>
                       <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
                         days
                       </span>

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -162,7 +162,23 @@
                   <div class="sm:col-span-1">
                     <%= form.label :available_on, class: "block text-sm font-medium text-gray-700" %>
                     <div class="mt-1">
-                      <%= form.date_field :available_on, class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center" %>
+                      <%= form.date_field :available_on, value: developer.available_on_in_database, class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center" %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-5 md:mt-0 md:col-span-2 space-y-6">
+              <div>
+                <div class="grid grid-cols-1 sm:grid-cols-3 sm:col-span-3 md:gap-6">
+                  <div class="sm:col-span-1">
+                    <%= form.label :available_in_days, class: "block text-sm font-medium text-gray-700" %>
+                    <div class="mt-1 flex rounded-md shadow-sm">
+                      <%= form.number_field :available_in_days, class: "flex-1 focus:ring-gray-500 focus:border-gray-500 block w-full min-w-0 rounded-none rounded-l-md sm:text-sm border-gray-300 border-r-0" %>
+                      <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
+                        days
+                      </span>
                     </div>
                   </div>
                 </div>

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -162,23 +162,21 @@
                   <div class="sm:col-span-1">
                     <%= form.label :available_on, class: "block text-sm font-medium text-gray-700" %>
                     <div class="mt-1 flex items-center w-full">
-                      <%= form.date_field :available_on, value: developer.available_on_in_database || '', class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center",
+                      <%= form.date_field :available_on, value: developer.available_on_in_database || "", class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md text-center",
                           data: {
-                            controller: 'clear-field',
+                            controller: "clear-field",
                             clear_field_target_value: 'input[name="developer[available_in_days]"]',
-                            action: 'input->clear-field#clear'
-                          }
-                      %>
-                      <%= button_tag 'Clear',
-                          name: 'clear_available_on',
-                          type: :button,
-                          class: "inline-flex justify-center align-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 cursor-pointer hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 ml-3",
-                          data: {
-                            controller: 'clear-field',
-                            clear_field_target_value: 'input[name="developer[available_on]"]',
-                            action: 'click->clear-field#clear'
-                          }
-                          %>
+                            action: "input->clear-field#clear"
+                          } %>
+                      <%= button_tag "Clear",
+                            name: "clear_available_on",
+                            type: :button,
+                            class: "inline-flex justify-center align-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 cursor-pointer hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 ml-3",
+                            data: {
+                              controller: "clear-field",
+                              clear_field_target_value: 'input[name="developer[available_on]"]',
+                              action: "click->clear-field#clear"
+                            } %>
                     </div>
                   </div>
                 </div>
@@ -193,11 +191,10 @@
                     <div class="mt-1 flex rounded-md shadow-sm">
                       <%= form.number_field :available_in_days, value: developer.available_on_in_database.present? ? nil : developer.available_in_days_in_database, class: "flex-1 focus:ring-gray-500 focus:border-gray-500 block w-full min-w-0 rounded-none rounded-l-md sm:text-sm border-gray-300 border-r-0",
                           data: {
-                            controller: 'clear-field',
+                            controller: "clear-field",
                             clear_field_target_value: 'input[name="developer[available_on]"]',
-                            action: 'input->clear-field#clear'
-                          }
-                      %>
+                            action: "input->clear-field#clear"
+                          } %>
                       <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
                         days
                       </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,8 +10,8 @@ en:
         company: Company name
         name: Your name
       developer:
-        available_on: Available to start on
         available_in_days: Available in
+        available_on: Available to start on
         bio: Bio
         email: E-mail
         github: Github

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
         name: Your name
       developer:
         available_on: Available to start on
+        available_in_days: Available in
         bio: Bio
         email: E-mail
         github: Github

--- a/db/migrate/20220203174743_add_available_in_days_to_developers.rb
+++ b/db/migrate/20220203174743_add_available_in_days_to_developers.rb
@@ -1,0 +1,5 @@
+class AddAvailableInDaysToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :available_in_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_031819) do
+ActiveRecord::Schema.define(version: 2022_02_03_174743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2022_01_31_031819) do
     t.integer "preferred_max_salary"
     t.string "time_zone"
     t.integer "utc_offset"
+    t.integer "available_in_days"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -119,6 +119,24 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_equal "New Name", developer.reload.name
   end
 
+  test "successful edit to relative availability" do
+    sign_in users(:with_available_profile)
+    developer = developers :available
+
+    get edit_developer_path(developer)
+    assert_select "form"
+
+    patch developer_path(developer), params: {
+      developer: {
+        available_in_days: 14
+      }
+    }
+    assert_redirected_to developer_path(developer)
+    follow_redirect!
+
+    assert_equal 14.days, developer.reload.available_in_days
+  end
+
   test "invalid profile creation" do
     sign_in users(:without_profile)
 

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -134,7 +134,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_redirected_to developer_path(developer)
     follow_redirect!
 
-    assert_equal 14.days, developer.reload.available_in_days
+    assert_equal 14, developer.reload.available_in_days
   end
 
   test "invalid profile creation" do

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -33,6 +33,42 @@ class DeveloperTest < ActiveSupport::TestCase
     assert @developer.available_now?
   end
 
+  test "unspecified relative availability" do
+    @developer.available_on = nil
+    @developer.available_in_days = nil
+
+    assert_equal "unspecified", @developer.availability_status
+    assert @developer.available_unspecified?
+  end
+
+  test "available in some time" do
+    @developer.available_on = nil
+    @developer.available_in_days = 14
+
+    assert_equal "in_future", @developer.availability_status
+    assert @developer.available_in_future?
+    assert_equal @developer.available_on, Date.current + 2.weeks
+  end
+
+  test "available from today with relative availability" do
+    @developer.available_on = nil
+    @developer.available_in_days = 0
+
+    assert_equal "now", @developer.availability_status
+    assert @developer.available_now?
+    assert_equal @developer.available_on, Date.current
+  end
+
+  test "negative availability should clamp to 0" do
+    @developer.available_on = nil
+    @developer.available_in_days = -1
+
+    assert_equal 0, @developer.available_in_days
+    assert_equal "now", @developer.availability_status
+    assert @developer.available_now?
+    assert_equal @developer.available_on, Date.current
+  end
+
   test "is valid" do
     assert Developer.new(valid_developer_attributes).valid?
   end


### PR DESCRIPTION
Developers may be immediately available after a given notice period (a fixed period of time). This PR aims to store that in days and use it instead of `available_on` if it's specified, meaning that developers won't have to revisit the platform daily to update the date on which they're available. Their availability is instead marked by a window of days.

![Two fields, marked "Available to start on" (with a Clear button beside it) and "Available in (days)". "Available to start on" is a date field, and "Available in (days)" is a number field.](https://user-images.githubusercontent.com/20680337/152523988-88ee0871-1465-478b-ae77-09fc16fa19dc.png)

Each field clears the other one if it is edited, so that both fields can't be set at the same time. If they are somehow both set, `available_on` takes priority. The `Clear` button allows a developer to set their availability to the `unspecified` state.

TODO:

- [x] Add to form
- [x] Make it easy to submit either a fixed date or a relative time period

Seems like right now, the default availability date on the form is the current date. It's probably better to make that fixed date `nil` if relative availability is set.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
