### PR TITLE
Bugfix: Show "Edit my profile" if the user has already a dev profile

### DIFF
--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -9,12 +9,19 @@
       <p class="mt-4 max-w-xl text-sm text-gray-700"><%= t(".description", developers_count: @developers_count) %></p>
     </div>
 
-    <div class="mt-4 flex space-x-3 md:mt-0">
-      <%= link_to new_developer_path, class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
-        <%= inline_svg_tag "icons/solid/plus_circle.svg", class: "-ml-1 mr-2 h-5 w-5" %>
-        <%= t(".cta") %>
-      <% end %>
-    </div>
+        <div class="mt-4 flex space-x-3 md:mt-0">
+          <% if current_user&.developer %>
+            <%= link_to developer_path(current_user.id), class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+              <%= inline_svg_tag "icons/solid/plus_circle.svg", class: "-ml-1 mr-2 h-5 w-5" %>
+              <%= t(".edit_profile") %>
+            <% end %>
+          <% else %>
+            <%= link_to new_developer_path, class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
+              <%= inline_svg_tag "icons/solid/plus_circle.svg", class: "-ml-1 mr-2 h-5 w-5" %>
+              <%= t(".cta") %>
+            <% end %>
+          <% end %>
+        </div>
   </div>
 
   <%= render DeveloperQueryComponent.new(@query) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,7 @@ en:
     index:
       cta: Add my profile
       description: "%{developers_count}+ Ruby on Rails developers looking for their next gig. Juniors to seniors and everyone in between, you'll find them all here."
+      edit_profile: Edit my profile
       title: Ruby on Rails developers
     show:
       description: Description

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -157,6 +157,7 @@ es:
         title: Preferencias de trabajo
     index:
       cta: Agregar a mi perfil
+      edit_profile: Editar mi perfil
       description: "Más de %{developers_count} desarrolladores de Ruby on Rails en busca de su próximo trabajo. De juniors a seniors y todos los intermedios, los encontrarás aquí."
       title: Desarrolladores Ruby on Rails
     show:

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -64,6 +64,22 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_developer_path(user.developer)
   end
 
+  test "add my profile button is shown if the user doesn't have a developer profile" do
+    user = users(:empty)
+    sign_in user
+    get developers_path
+
+    assert_select "a", text: "Add my profile"
+  end
+
+  test "edit my profile button is shown if the user has a developer profile" do
+    user = users(:with_available_profile)
+    sign_in user
+    get developers_path
+
+    assert_select "a", text: "Edit my profile"
+  end
+
   test "successful profile creation" do
     sign_in users(:without_profile)
 


### PR DESCRIPTION
Fixes #229 
-> In the developers index, show "Edit my profile" in the CTA button if the user has already a developer profile
<img width="1073" alt="Edit my profile button" src="https://user-images.githubusercontent.com/17859704/152671297-25dedc88-21e8-4e32-a42e-b930bf446288.png">
### Pull request checklist


- [X] Your code contains tests relevant for code you modified
- [X] You have linted and tested the project with `bin/check`


