### PR TITLE
Fixes container padding on password reset page

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render "shared/error_messages", resource: resource %>
 
-<div class="flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
-  <div class="mx-auto w-full max-w-sm lg:w-96">
+<div class="flex flex-col justify-center flex-1 px-4 py-12 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+  <div class="w-full max-w-sm mx-auto lg:w-96">
     <div>
       <h2 class="text-3xl font-extrabold text-gray-900">
         <%= t("devise.passwords.edit.change_your_password") %>
@@ -11,7 +11,7 @@
     </div>
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-      <div class="mt-6 bg-white sm:rounded-lg">
+      <div class="p-4 px-4 pb-8 bg-white shadow sm:rounded-lg sm:px-10">
         <%= form_for resource, as: resource_name, url: password_path(resource_name), html: {method: :put, class: "space-y-6", data: {turbo: false}} do |f| %>
           <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/error_messages", resource: resource %>
 
-<div class="flex flex-col justify-center flex-1 px-4 py-12 sm:px-6 lg:flex-none lg:px-20 xl:px-24">
+<div class="flex flex-col justify-center min-h-full py-12 sm:px-6 lg:px-8">
   <div class="w-full max-w-sm mx-auto lg:w-96">
     <div>
       <h2 class="text-3xl font-extrabold text-gray-900">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,39 +1,37 @@
 <%= render "shared/error_messages", resource: resource %>
 
 <div class="flex flex-col justify-center min-h-full py-12 sm:px-6 lg:px-8">
-  <div class="w-full max-w-sm mx-auto lg:w-96">
-    <div>
-      <h2 class="text-3xl font-extrabold text-gray-900">
-        <%= t("devise.passwords.edit.change_your_password") %>
-      </h2>
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
+      <%= t("devise.passwords.edit.change_your_password") %>
+    </h2>
 
-      <%= render "devise/shared/signup_link" if devise_mapping.registerable? %>
-    </div>
+    <%= render "devise/shared/signup_link" if devise_mapping.registerable? %>
+  </div>
 
-    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-      <div class="p-4 px-4 pb-8 bg-white shadow sm:rounded-lg sm:px-10">
-        <%= form_for resource, as: resource_name, url: password_path(resource_name), html: {method: :put, class: "space-y-6", data: {turbo: false}} do |f| %>
-          <%= f.hidden_field :reset_password_token %>
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="p-4 px-4 pb-8 bg-white shadow sm:rounded-lg sm:px-10">
+      <%= form_for resource, as: resource_name, url: password_path(resource_name), html: {method: :put, class: "space-y-6", data: {turbo: false}} do |f| %>
+        <%= f.hidden_field :reset_password_token %>
 
-          <div>
-            <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
-            <div class="mt-1">
-              <%= f.password_field :password, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
-            </div>
+        <div>
+          <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
           </div>
+        </div>
 
-          <div>
-            <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
-            <div class="mt-1">
-              <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
-            </div>
+        <div>
+          <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+          <div class="mt-1">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
           </div>
+        </div>
 
-          <div>
-            <%= f.submit t("devise.passwords.edit.change_my_password"), class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
-          </div>
-        <% end %>
-      </div>
+        <div>
+          <%= f.submit t("devise.passwords.edit.change_my_password"), class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes UI container padding on the password reset page 

### Before & After screenshot 

![image](https://user-images.githubusercontent.com/1650995/153628814-cc05c55a-a764-44c7-9a05-76cd2e93485e.png)


![image](https://user-images.githubusercontent.com/1650995/153628866-e37772c7-7595-4240-81ee-bacecc17b6e5.png)


### Pull request checklist

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`
