### PR TITLE
Event tracking via Fathom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 5.2)
     highline (2.0.3)
     honeybadger (4.9.0)
-    hotwire-livereload (0.2.0)
+    hotwire-livereload (1.1.0)
       listen (>= 3.0.0)
       rails (>= 6.0.0)
     hotwire-rails (0.1.3)

--- a/app/components/analytics_event_component.html.erb
+++ b/app/components/analytics_event_component.html.erb
@@ -1,0 +1,1 @@
+<%= tag.div data: data %>

--- a/app/components/analytics_event_component.rb
+++ b/app/components/analytics_event_component.rb
@@ -1,0 +1,31 @@
+class AnalyticsEventComponent < ApplicationComponent
+  def initialize(flash)
+    @flash = flash
+  end
+
+  def render?
+    event.present? && goal.present? && value.present?
+  end
+
+  def data
+    {
+      controller: "analytics--events",
+      "analytics--events-goal-value": goal,
+      "analytics--events-value-value": value
+    }
+  end
+
+  private
+
+  def goal
+    event["goal"]
+  end
+
+  def value
+    event["value"]
+  end
+
+  def event
+    @flash[:event]
+  end
+end

--- a/app/controllers/analytics/events_controller.rb
+++ b/app/controllers/analytics/events_controller.rb
@@ -3,8 +3,8 @@ module Analytics
     def show
       event = Analytics::Event.find(params[:id])
 
-      unless event.read?
-        event.mark_as_read!
+      unless event.tracked?
+        event.mark_as_tracked!
         flash[:event] = {goal: event.goal, value: event.value}
       end
 

--- a/app/controllers/analytics/events_controller.rb
+++ b/app/controllers/analytics/events_controller.rb
@@ -1,0 +1,14 @@
+module Analytics
+  class EventsController < ApplicationController
+    def show
+      event = Analytics::Event.find(params[:id])
+
+      unless event.read?
+        event.mark_as_read!
+        flash[:event] = {goal: event.goal, value: event.value}
+      end
+
+      redirect_to event.url
+    end
+  end
+end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -11,8 +11,9 @@ class BusinessesController < ApplicationController
     @business.assign_attributes(permitted_attributes(@business))
 
     if @business.save
-      path = stored_location_for(:user) || developers_path
-      redirect_to path, notice: t(".created")
+      url = stored_location_for(:user) || developers_path
+      event = Analytics::Event.created_business_profile(url)
+      redirect_to event, notice: t(".created")
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -15,7 +15,8 @@ class DevelopersController < ApplicationController
     @developer = current_user.build_developer(developer_params)
 
     if @developer.save
-      redirect_to @developer, notice: t(".created")
+      event = Analytics::Event.created_developer_profile(@developer)
+      redirect_to event, notice: t(".created")
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/analytics/events_controller.js
+++ b/app/javascript/controllers/analytics/events_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    goal: String,
+    value: {type: Number, default: 0}
+  }
+
+  connect() {
+    window.addEventListener("turbo:load", (event) => {
+      window.fathom.trackGoal(this.goalValue, this.valueValue)
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,9 @@
 
 import { application } from "./application"
 
+import Analytics__EventsController from "./analytics/events_controller.js"
+application.register("analytics--events", Analytics__EventsController)
+
 import FileUploadController from "./file_upload_controller.js"
 application.register("file-upload", FileUploadController)
 

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["element"]
   static classes = ["open", "close"]
   static values = {
-    open: { type: Boolean, default: false }
+    open: {type: Boolean, default: false}
   }
 
   openValueChanged() {

--- a/app/models/analytics/event.rb
+++ b/app/models/analytics/event.rb
@@ -18,6 +18,10 @@ module Analytics
         Analytics::Event.create!(url:, goal: goals.created_business_profile)
       end
 
+      def created_business_subscription(url)
+        Analytics::Event.create!(url:, goal: goals.created_business_subscription, value: 9900)
+      end
+
       def goals
         Rails.configuration.analytics
       end

--- a/app/models/analytics/event.rb
+++ b/app/models/analytics/event.rb
@@ -1,0 +1,30 @@
+module Analytics
+  class Event < ApplicationRecord
+    self.table_name = "analytics_events"
+
+    validates :url, presence: true
+    validates :goal, presence: true
+    validates :value, presence: true, numericality: {greater_than_or_equal_to: 0}
+
+    class << self
+      include UrlHelpersWithDefaultUrlOptions
+
+      def created_developer_profile(developer)
+        url = developer_path(developer)
+        Analytics::Event.create!(url:, goal: goals.created_developer_profile)
+      end
+
+      def goals
+        Rails.configuration.analytics
+      end
+    end
+
+    def read?
+      read_at.present?
+    end
+
+    def mark_as_read!
+      touch(:read_at)
+    end
+  end
+end

--- a/app/models/analytics/event.rb
+++ b/app/models/analytics/event.rb
@@ -14,6 +14,10 @@ module Analytics
         Analytics::Event.create!(url:, goal: goals.created_developer_profile)
       end
 
+      def created_business_profile(url)
+        Analytics::Event.create!(url:, goal: goals.created_business_profile)
+      end
+
       def goals
         Rails.configuration.analytics
       end

--- a/app/models/analytics/event.rb
+++ b/app/models/analytics/event.rb
@@ -11,15 +11,15 @@ module Analytics
 
       def created_developer_profile(developer)
         url = developer_path(developer)
-        Analytics::Event.create!(url:, goal: goals.created_developer_profile)
+        Analytics::Event.create!(url:, goal: goals.added_developer_profile)
       end
 
       def created_business_profile(url)
-        Analytics::Event.create!(url:, goal: goals.created_business_profile)
+        Analytics::Event.create!(url:, goal: goals.added_business_profile)
       end
 
       def created_business_subscription(url)
-        Analytics::Event.create!(url:, goal: goals.created_business_subscription, value: 9900)
+        Analytics::Event.create!(url:, goal: goals.subscribed_to_busines_plan, value: 9900)
       end
 
       def goals

--- a/app/models/analytics/event.rb
+++ b/app/models/analytics/event.rb
@@ -27,12 +27,12 @@ module Analytics
       end
     end
 
-    def read?
-      read_at.present?
+    def tracked?
+      tracked_at.present?
     end
 
-    def mark_as_read!
-      touch(:read_at)
+    def mark_as_tracked!
+      touch(:tracked_at)
     end
   end
 end

--- a/app/models/business_subscription_checkout.rb
+++ b/app/models/business_subscription_checkout.rb
@@ -19,7 +19,7 @@ class BusinessSubscriptionCheckout
     user.payment_processor.checkout(
       mode: "subscription",
       line_items: business_subscription_price_id,
-      success_url:
+      success_url: analytics_event_url(event)
     )
   end
 
@@ -27,13 +27,17 @@ class BusinessSubscriptionCheckout
     Rails.application.credentials.stripe[:price_id]
   end
 
-  def success_url
+  def event
+    @event ||= Analytics::Event.created_business_subscription(redirect_to)
+  end
+
+  def redirect_to
     if developer.present?
-      new_developer_message_url(developer)
+      new_developer_message_path(developer)
     elsif user.business.present?
-      conversations_url
+      conversations_path
     else
-      new_business_url
+      new_business_path
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,5 +30,6 @@
     </div>
     <%= render "shared/footer" %>
     <%= turbo_frame_tag "modal" %>
+    <%= render AnalyticsEventComponent.new(flash) %>
   </body>
 </html>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,0 +1,8 @@
+development:
+  created_developer_profile: ACZJLHEM
+
+test:
+  created_developer_profile: TEST_DEV
+
+production:
+  created_developer_profile: BDHJV6OB

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,8 +1,11 @@
 development:
   created_developer_profile: ACZJLHEM
+  created_business_profile: EGNOLFJL
 
 test:
   created_developer_profile: TEST_DEV
+  created_business_profile: TEST_BIZ
 
 production:
   created_developer_profile: BDHJV6OB
+  created_business_profile: OYBFYEJK

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,11 +1,14 @@
 development:
   created_developer_profile: ACZJLHEM
   created_business_profile: EGNOLFJL
+  created_business_subscription: IWOCMRQ3
 
 test:
   created_developer_profile: TEST_DEV
   created_business_profile: TEST_BIZ
+  created_business_subscription: TEST_SUB
 
 production:
   created_developer_profile: BDHJV6OB
   created_business_profile: OYBFYEJK
+  created_business_subscription: 3HOXYNYL

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,14 +1,14 @@
 development:
-  created_developer_profile: ACZJLHEM
-  created_business_profile: EGNOLFJL
-  created_business_subscription: IWOCMRQ3
+  added_developer_profile: ACZJLHEM
+  added_business_profile: EGNOLFJL
+  subscribed_to_busines_plan: IWOCMRQ3
 
 test:
-  created_developer_profile: TEST_DEV
-  created_business_profile: TEST_BIZ
-  created_business_subscription: TEST_SUB
+  added_developer_profile: TEST_DEV
+  added_business_profile: TEST_BIZ
+  subscribed_to_busines_plan: TEST_SUB
 
 production:
-  created_developer_profile: BDHJV6OB
-  created_business_profile: OYBFYEJK
-  created_business_subscription: 3HOXYNYL
+  added_developer_profile: BDHJV6OB
+  added_business_profile: OYBFYEJK
+  subscribed_to_busines_plan: 3HOXYNYL

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module Railsdevs
 
     # Load custom configuration.
     config.fathom = config_for(:fathom)
+    config.analytics = config_for(:analytics)
     config.support_email = "joe@masilotti.com"
     config.upload_sitemap = false
     config.sitemaps_host = "https://#{Rails.application.credentials.dig(:aws, :sitemaps_bucket)}.s3.#{Rails.application.credentials.dig(:aws, :region)}.amazonaws.com/"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     resources :read_notifications, only: :index, path: "/notifications/read"
     resources :notifications, only: %i[index show]
 
+    namespace :analytics do
+      resources :events, only: :show
+    end
+
     resources :conversations, only: %i[index show] do
       resources :messages, only: :create
       resource :block, only: %i[new create]

--- a/db/migrate/20220214204932_create_analytics_events.rb
+++ b/db/migrate/20220214204932_create_analytics_events.rb
@@ -1,0 +1,12 @@
+class CreateAnalyticsEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :analytics_events do |t|
+      t.string :url, null: false
+      t.string :goal, null: false
+      t.integer :value, null: false, default: 0
+      t.timestamp :read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220214204932_create_analytics_events.rb
+++ b/db/migrate/20220214204932_create_analytics_events.rb
@@ -4,7 +4,7 @@ class CreateAnalyticsEvents < ActiveRecord::Migration[7.0]
       t.string :url, null: false
       t.string :goal, null: false
       t.integer :value, null: false, default: 0
-      t.timestamp :read_at
+      t.timestamp :tracked_at
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_031819) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_02_14_204932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +40,15 @@ ActiveRecord::Schema.define(version: 2022_01_31_031819) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "analytics_events", force: :cascade do |t|
+    t.string "url", null: false
+    t.string "goal", null: false
+    t.integer "value", default: 0, null: false
+    t.datetime "read_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "businesses", force: :cascade do |t|

--- a/test/components/analytics_event_component_test.rb
+++ b/test/components/analytics_event_component_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class AnalyticsEventComponentTest < ViewComponent::TestCase
+  test "does not render unless the goal and value are present in the hash" do
+    render_inline AnalyticsEventComponent.new({})
+    assert_no_select "*"
+
+    render_inline AnalyticsEventComponent.new(event: {"goal" => "ABC123"})
+    assert_no_select "*"
+
+    render_inline AnalyticsEventComponent.new(event: {"value" => "4200"})
+    assert_no_select "*"
+  end
+
+  test "renders the Stimulus controller with goal and value values" do
+    event = {"goal" => "ABC123", "value" => 4200}
+    render_inline AnalyticsEventComponent.new(event:)
+    assert_selector ""\
+      "[data-controller=analytics--events]"\
+      "[data-analytics--events-goal-value=ABC123]"\
+      "[data-analytics--events-value-value=4200]"
+  end
+end

--- a/test/fixtures/analytics/events.yml
+++ b/test/fixtures/analytics/events.yml
@@ -1,0 +1,4 @@
+one:
+  url: /developers/1
+  goal: ABC123
+  value: 4200

--- a/test/integration/analytics/events_test.rb
+++ b/test/integration/analytics/events_test.rb
@@ -17,11 +17,11 @@ class Analytics::EventsTest < ActionDispatch::IntegrationTest
 
   test "viewing an event marks it as viewed" do
     get analytics_event_path(@event)
-    assert @event.reload.read?
+    assert @event.reload.tracked?
   end
 
   test "viewing an already viewed event does not render the flash" do
-    @event.mark_as_read!
+    @event.mark_as_tracked!
     get analytics_event_path(@event)
     assert_nil flash[:event]
   end

--- a/test/integration/analytics/events_test.rb
+++ b/test/integration/analytics/events_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Analytics::EventsTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = analytics_events(:one)
+  end
+
+  test "viewing an event sets the flash" do
+    get analytics_event_path(@event)
+    assert_equal flash[:event], {goal: @event.goal, value: @event.value}
+  end
+
+  test "viewing an event redirects to the URL" do
+    get analytics_event_path(@event)
+    assert_redirected_to @event.url
+  end
+
+  test "viewing an event marks it as viewed" do
+    get analytics_event_path(@event)
+    assert @event.reload.read?
+  end
+
+  test "viewing an already viewed event does not render the flash" do
+    @event.mark_as_read!
+    get analytics_event_path(@event)
+    assert_nil flash[:event]
+  end
+end

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -37,11 +37,12 @@ class BusinessesTest < ActionDispatch::IntegrationTest
     user = users(:empty)
     sign_in user
 
-    assert_difference "Business.count", 1 do
+    assert_difference ["Business.count", "Analytics::Event.count"], 1 do
       post businesses_path, params: valid_business_params
     end
     assert_equal "basecamp.png", user.business.avatar.filename.to_s
-    assert_redirected_to developers_path
+    assert_redirected_to Analytics::Event.last
+    assert_equal Analytics::Event.last.url, developers_path
   end
 
   test "successful business creation with a stored location" do
@@ -51,10 +52,9 @@ class BusinessesTest < ActionDispatch::IntegrationTest
     post developer_messages_path(developer)
     assert_redirected_to new_business_path
 
-    assert_difference "Business.count", 1 do
-      post businesses_path, params: valid_business_params
-    end
-    assert_redirected_to developer_messages_path(developer)
+    post businesses_path, params: valid_business_params
+    assert_redirected_to Analytics::Event.last
+    assert_equal Analytics::Event.last.url, developer_messages_path(developer)
   end
 
   test "successful edit to business" do

--- a/test/integration/cold_messages_test.rb
+++ b/test/integration/cold_messages_test.rb
@@ -25,9 +25,10 @@ class ColdMessagesTest < ActionDispatch::IntegrationTest
 
   test "must have an active business subscription" do
     sign_in businesses(:one).user
-    stub_pay(businesses(:one).user, expected_success_url: new_developer_message_url(@developer)) do
+    stub_pay(businesses(:one).user) do
       get new_developer_message_path(@developer)
       assert_redirected_to "checkout.stripe.com"
+      assert_equal Analytics::Event.last.url, new_developer_message_path(@developer)
     end
   end
 

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -77,9 +77,11 @@ class DevelopersTest < ActionDispatch::IntegrationTest
   test "successful profile creation" do
     sign_in users(:without_profile)
 
-    assert_difference "Developer.count", 1 do
+    assert_difference ["Developer.count", "Analytics::Event.count"], 1 do
       post developers_path, params: valid_developer_params
     end
+    assert_redirected_to analytics_event_path(Analytics::Event.last)
+    assert_equal Analytics::Event.last.url, developer_path(Developer.last)
   end
 
   test "create with nested attributes" do

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -57,11 +57,12 @@ class MessagesTest < ActionDispatch::IntegrationTest
     pay_subscriptions(:two).update!(status: :incomplete)
     sign_in @business.user
 
-    stub_pay(@business.user, expected_success_url: new_developer_message_url(@developer)) do
+    stub_pay(@business.user) do
       assert_no_difference "Message.count" do
         post conversation_messages_path(@conversation), params: message_params
       end
       assert_redirected_to "checkout.stripe.com"
+      assert_equal Analytics::Event.last.url, new_developer_message_path(@developer)
     end
   end
 

--- a/test/models/analytics/event_test.rb
+++ b/test/models/analytics/event_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 
 class AnalytisEventTest < ActiveSupport::TestCase
-  test "is read if read_at is set" do
+  test "is tracked if tracked_at is set" do
     travel_to now do
       event = analytics_events(:one)
-      refute event.read?
-      assert_nil event.read_at
+      refute event.tracked?
+      assert_nil event.tracked_at
 
-      event.mark_as_read!
-      assert event.read?
-      assert_equal event.read_at, now
+      event.mark_as_tracked!
+      assert event.tracked?
+      assert_equal event.tracked_at, now
     end
   end
 

--- a/test/models/analytics/event_test.rb
+++ b/test/models/analytics/event_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class AnalytisEventTest < ActiveSupport::TestCase
+  test "is read if read_at is set" do
+    travel_to now do
+      event = analytics_events(:one)
+      refute event.read?
+      assert_nil event.read_at
+
+      event.mark_as_read!
+      assert event.read?
+      assert_equal event.read_at, now
+    end
+  end
+
+  def now
+    Time.zone.local(2021, 6, 26, 1, 15)
+  end
+end

--- a/test/models/business_subscription_checkout_test.rb
+++ b/test/models/business_subscription_checkout_test.rb
@@ -19,22 +19,31 @@ class BusinessSubscriptionCheckoutTest < ActiveSupport::TestCase
     user = users(:with_business)
     developer = developers(:available)
 
-    stub_pay(user, expected_success_url: new_developer_message_url(developer)) do
-      BusinessSubscriptionCheckout.new(user, developer:).url
+    stub_pay(user) do
+      assert_difference "Analytics::Event.count", 1 do
+        BusinessSubscriptionCheckout.new(user, developer:).url
+      end
+      assert_equal Analytics::Event.last.url, new_developer_message_path(developer)
     end
   end
 
   test "redirects to conversations if the user has a business profile" do
     user = users(:with_business)
-    stub_pay(user, expected_success_url: conversations_url) do
-      BusinessSubscriptionCheckout.new(user).url
+    stub_pay(user) do
+      assert_difference "Analytics::Event.count", 1 do
+        BusinessSubscriptionCheckout.new(user).url
+      end
+      assert_equal Analytics::Event.last.url, conversations_path
     end
   end
 
   test "redirects to adding a business profile if the user doesn't have one" do
     user = users(:empty)
-    stub_pay(user, expected_success_url: new_business_url) do
-      BusinessSubscriptionCheckout.new(user).url
+    stub_pay(user) do
+      assert_difference "Analytics::Event.count", 1 do
+        BusinessSubscriptionCheckout.new(user).url
+      end
+      assert_equal Analytics::Event.last.url, new_business_path
     end
   end
 

--- a/test/support/helpers/pay_helper.rb
+++ b/test/support/helpers/pay_helper.rb
@@ -2,16 +2,14 @@ module PayHelper
   extend ActiveSupport::Concern
 
   included do
-    def stub_pay(user, expected_success_url: conversations_url)
+    def stub_pay(user)
       checkout = Minitest::Mock.new
       checkout.expect(:url, "checkout.stripe.com")
 
       payment_processor = Minitest::Mock.new
-      payment_processor.expect(:checkout, checkout, [{
-        mode: "subscription",
-        line_items: "price_FAKE_PRICE_ID_FOR_TESTS",
-        success_url: expected_success_url
-      }])
+      payment_processor.expect(:checkout, checkout) do |options|
+        options[:mode] == "subscription" && options[:line_items] == "price_FAKE_PRICE_ID_FOR_TESTS"
+      end
 
       user.stub(:payment_processor, payment_processor) do
         yield


### PR DESCRIPTION
This PR adds client-side event (goal) tracking via [Fathom](https://usefathom.com/ref/HBTNVR).

Since Fathom only works client-side, I had to jump through a few hoops to get everything working. First, whenever a critical event occurs (a developer profile is added, a business profile is added, or a business subscribes to a paid plan) the controller creates a `Analytics::Event` record. This stores the URL to actually redirect to.

Then, when the first redirect occurs, `Analytics::EventsController` sets some content in the flash about the event (goal) to track. This is rendered via `AnalyticsEventsComponent` on the _second_ redirect to trigger a Stimulus controller to call the Fathom JavaScript to track the event.

### Pull request checklist

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`