### PR TITLE
Anonymize avatar filenames

### DIFF
--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -13,7 +13,9 @@ module Avatarable
     private
 
     def anonymize_avatar_filename
-      avatar.blob.filename = "avatar#{avatar.filename.extension_with_delimiter}"
+      if avatar.attached?
+        avatar.blob.filename = "avatar#{avatar.filename.extension_with_delimiter}"
+      end
     end
   end
 end

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -7,5 +7,13 @@ module Avatarable
     validates :avatar, content_type: ["image/png", "image/jpeg", "image/jpg"],
       max_file_size: 2.megabytes
     validates :avatar, attached: true, on: :create
+
+    before_save :anonymize_avatar_filename
+
+    private
+
+    def anonymize_avatar_filename
+      avatar.blob.filename = "avatar#{avatar.filename.extension_with_delimiter}"
+    end
   end
 end

--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -1,12 +1,15 @@
 desc "These tasks are meant to be run once then removed"
 namespace :backfills do
-  desc "Backfill developers.time_zone to locations.time_zone"
-  task time_zone: :environment do
-    Developer.where.not(time_zone: [nil, ""]).find_each do |developer|
-      time_zone = ActiveSupport::TimeZone.new(developer.time_zone)
-      location = developer.location
-      location.assign_attributes(time_zone: time_zone.tzinfo.name, utc_offset: time_zone.utc_offset)
-      location.save!(context: :backfill)
+  desc "Anonymize developer and business avatar filenames"
+  task anonymize_avatar_filenames: :environment do
+    Developer.joins(:avatar_attachment).with_attached_avatar.find_each do |developer|
+      filename = "avatar#{developer.avatar.filename.extension_with_delimiter}"
+      developer.avatar.blob.update!(filename:)
+    end
+
+    Business.joins(:avatar_attachment).with_attached_avatar.find_each do |developer|
+      filename = "avatar#{developer.avatar.filename.extension_with_delimiter}"
+      developer.avatar.blob.update!(filename:)
     end
   end
 end

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -40,7 +40,7 @@ class BusinessesTest < ActionDispatch::IntegrationTest
     assert_difference ["Business.count", "Analytics::Event.count"], 1 do
       post businesses_path, params: valid_business_params
     end
-    assert_equal "basecamp.png", user.business.avatar.filename.to_s
+    assert user.business.avatar.attached?
     assert_redirected_to Analytics::Event.last
     assert_equal Analytics::Event.last.url, developers_path
   end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -102,7 +102,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     end
 
     assert user.developer.role_type.part_time_contract?
-    assert_equal "lovelace.jpg", user.developer.avatar.filename.to_s
+    assert user.developer.avatar.attached?
   end
 
   test "edit with nested attributes" do

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -45,6 +45,11 @@ class BusinessTest < ActiveSupport::TestCase
     end
   end
 
+  test "anonymizes the filename of the avatar" do
+    developer = Business.create!(valid_business_attributes)
+    assert_equal developer.avatar.filename, "avatar.jpg"
+  end
+
   test "should require new developer notifications" do
     @business.developer_notifications = nil
     refute @business.valid?

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -114,6 +114,11 @@ class DeveloperTest < ActiveSupport::TestCase
     end
   end
 
+  test "anonymizes the filename of the avatar" do
+    developer = Developer.create!(developer_attributes)
+    assert_equal developer.avatar.filename, "avatar.jpg"
+  end
+
   test "should accept cover images of valid file formats" do
     valid_formats = %w[image/png image/jpeg image/jpg]
 


### PR DESCRIPTION
This PR fixes a small security issue where attachment filenames could leak personal information about the developer or business. If, for example, I upload my avatar with the filename `joemasilotti.jpg` then someone could see that filename (and therefore my name) in their browser's DOM or network inspector.

The code changes rename every avatar upload to `avatar.jpg`, where `.jpg` is the original filename extension. It also includes a backfill to fix existing records.

### Pull request checklist

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`