### PR TITLE
Clean up Open Graph meta tags

### DIFF
--- a/app/components/developer_open_graph_tags_component.rb
+++ b/app/components/developer_open_graph_tags_component.rb
@@ -4,7 +4,7 @@ class DeveloperOpenGraphTagsComponent < OpenGraphTagsComponent
   end
 
   def title
-    @developer.hero
+    [@developer.hero, "railsdevs"].join(" · ")
   end
 
   def description

--- a/app/components/open_graph_tags_component.html.erb
+++ b/app/components/open_graph_tags_component.html.erb
@@ -1,4 +1,5 @@
 <% content_for :open_graph_tags do %>
+  <title><%= title %></title>
 
   <%= tag.meta property: "og:type", content: "website" %>
   <%= tag.meta property: "og:title", content: title %>

--- a/app/components/open_graph_tags_component.html.erb
+++ b/app/components/open_graph_tags_component.html.erb
@@ -1,17 +1,16 @@
-<% content_for :open_graph_tags do %>
-  <title><%= title %></title>
+<title><%= title %></title>
+<%= tag.meta property: "description", content: description %>
 
-  <%= tag.meta property: "og:type", content: "website" %>
-  <%= tag.meta property: "og:title", content: title %>
-  <%= tag.meta property: "og:description", content: description %>
-  <%= tag.meta property: "og:url", content: url %>
+<%= tag.meta property: "og:type", content: "website" %>
+<%= tag.meta property: "og:title", content: title %>
+<%= tag.meta property: "og:description", content: description %>
+<%= tag.meta property: "og:url", content: url %>
 
-  <% if image.present? %>
-    <%= tag.meta property: "og:image", content: image %>
-  <% end %>
+<% if image.present? %>
+  <%= tag.meta property: "og:image", content: image %>
+<% end %>
 
-  <%= tag.meta property: "twitter:card", content: "summary" %>
-  <% if twitter.present? %>
-    <%= tag.meta property: "twitter:site", content: twitter %>
-  <% end %>
+<%= tag.meta property: "twitter:card", content: "summary" %>
+<% if twitter.present? %>
+  <%= tag.meta property: "twitter:site", content: twitter %>
 <% end %>

--- a/app/components/open_graph_tags_component.html.erb
+++ b/app/components/open_graph_tags_component.html.erb
@@ -1,13 +1,16 @@
-<%= tag.meta property: "og:type", content: "website" %>
-<%= tag.meta property: "og:title", content: title %>
-<%= tag.meta property: "og:description", content: description %>
-<%= tag.meta property: "og:url", content: url %>
+<% content_for :open_graph_tags do %>
 
-<% if image.present? %>
-  <%= tag.meta property: "og:image", content: image %>
-<% end %>
+  <%= tag.meta property: "og:type", content: "website" %>
+  <%= tag.meta property: "og:title", content: title %>
+  <%= tag.meta property: "og:description", content: description %>
+  <%= tag.meta property: "og:url", content: url %>
 
-<%= tag.meta property: "twitter:card", content: "summary" %>
-<% if twitter.present? %>
-  <%= tag.meta property: "twitter:site", content: twitter %>
+  <% if image.present? %>
+    <%= tag.meta property: "og:image", content: image %>
+  <% end %>
+
+  <%= tag.meta property: "twitter:card", content: "summary" %>
+  <% if twitter.present? %>
+    <%= tag.meta property: "twitter:site", content: twitter %>
+  <% end %>
 <% end %>

--- a/app/components/open_graph_tags_component.rb
+++ b/app/components/open_graph_tags_component.rb
@@ -6,7 +6,11 @@ class OpenGraphTagsComponent < ApplicationComponent
   end
 
   def title
-    @title || "railsdevs"
+    if @title.present?
+      "#{@title} · railsdevs"
+    else
+      "railsdevs"
+    end
   end
 
   def description

--- a/app/components/open_graph_tags_component.rb
+++ b/app/components/open_graph_tags_component.rb
@@ -14,7 +14,7 @@ class OpenGraphTagsComponent < ApplicationComponent
   end
 
   def description
-    @description || t("open_graph_tags_component.default_description")
+    @description || t("home.show.title_og")
   end
 
   def url

--- a/app/helpers/meta_helper.rb
+++ b/app/helpers/meta_helper.rb
@@ -1,5 +1,6 @@
 module MetaHelper
   def open_graph_tags
-    content_for :open_graph_tags
+    render(OpenGraphTagsComponent.new) unless content_for?(:open_graph_tags)
+    content_for(:open_graph_tags)
   end
 end

--- a/app/helpers/meta_helper.rb
+++ b/app/helpers/meta_helper.rb
@@ -1,6 +1,0 @@
-module MetaHelper
-  def open_graph_tags
-    render(OpenGraphTagsComponent.new) unless content_for?(:open_graph_tags)
-    content_for(:open_graph_tags)
-  end
-end

--- a/app/helpers/open_graph_tags_helper.rb
+++ b/app/helpers/open_graph_tags_helper.rb
@@ -1,0 +1,12 @@
+module OpenGraphTagsHelper
+  def open_graph_tags(options = {})
+    content_for(:open_graph_tags) do
+      component = options.delete(:component) || OpenGraphTagsComponent
+      render component.new(**options)
+    end
+  end
+
+  def render_open_graph_tags
+    content_for(:open_graph_tags) || render(OpenGraphTagsComponent.new)
+  end
+end

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description")) %>
 
 <div class="overflow-hidden max-w-5xl mx-auto">
   <div class="relative max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description")) %>
+<%= open_graph_tags title: t(".title_og"), description: t(".description") %>
 
 <div class="overflow-hidden max-w-5xl mx-auto">
   <div class="relative max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description", developers_count: @developers_count)) %>
+<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description", developers_count: @developers_count).html_safe) %>
 
 <div class="bg-white max-w-5xl mx-auto lg:mt-16 mb-16 shadow overflow-auto sm:rounded-md">
   <div class="py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-4">

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description", developers_count: @developers_count)) %>
+<%= open_graph_tags title: t(".title_og"), description: t(".description", developers_count: @developers_count) %>
 
 <div class="bg-white max-w-5xl mx-auto lg:mt-16 mb-16 shadow overflow-auto sm:rounded-md">
   <div class="py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-4">

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description", developers_count: @developers_count)) %>
 
 <div class="bg-white max-w-5xl mx-auto lg:mt-16 mb-16 shadow overflow-auto sm:rounded-md">
   <div class="py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-4">

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description", developers_count: @developers_count).html_safe) %>
+<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description", developers_count: @developers_count)) %>
 
 <div class="bg-white max-w-5xl mx-auto lg:mt-16 mb-16 shadow overflow-auto sm:rounded-md">
   <div class="py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-4">

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render DeveloperOpenGraphTagsComponent.new(developer: @developer) %>
-<% end %>
+<%= render DeveloperOpenGraphTagsComponent.new(developer: @developer) %>
 
 <div class="max-w-5xl mx-auto mt-0 lg:mt-16 pb-8 mb-16 bg-white shadow lg:rounded-lg overflow-hidden">
   <%= render CoverImageComponent.new(developer: @developer, classes: "lg:rounded-t-lg") %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,4 +1,4 @@
-<%= render DeveloperOpenGraphTagsComponent.new(developer: @developer) %>
+<%= open_graph_tags component: DeveloperOpenGraphTagsComponent, developer: @developer %>
 
 <div class="max-w-5xl mx-auto mt-0 lg:mt-16 pb-8 mb-16 bg-white shadow lg:rounded-lg overflow-hidden">
   <%= render CoverImageComponent.new(developer: @developer, classes: "lg:rounded-t-lg") %>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new %>
+<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description_og")) %>
 
 <div class="mt-16 mx-auto max-w-7xl px-4 sm:mt-24">
   <div class="text-center">

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: t(".description_og")) %>
+<%= open_graph_tags title: t(".title_og"), description: t(".description_og") %>
 
 <div class="mt-16 mx-auto max-w-7xl px-4 sm:mt-24">
   <div class="text-center">

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new %>
-<% end %>
+<%= render OpenGraphTagsComponent.new %>
 
 <div class="mt-16 mx-auto max-w-7xl px-4 sm:mt-24">
   <div class="text-center">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
-    <title>Rails Devs</title>
-
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= open_graph_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= open_graph_tags %>
+    <%= render_open_graph_tags %>
     <%= render "shared/favicon_tags" %>
     <%= render AlternateLinksComponent.new %>
 

--- a/app/views/open_startup/contributions/index.html.erb
+++ b/app/views/open_startup/contributions/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/contributions/index.html.erb
+++ b/app/views/open_startup/contributions/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
+<%= open_graph_tags title: t(".title"), description: t(".description") %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/dashboard/show.html.erb
+++ b/app/views/open_startup/dashboard/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/dashboard/show.html.erb
+++ b/app/views/open_startup/dashboard/show.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
+<%= open_graph_tags title: t(".title"), description: t(".description") %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/expenses/index.html.erb
+++ b/app/views/open_startup/expenses/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/expenses/index.html.erb
+++ b/app/views/open_startup/expenses/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
+<%= open_graph_tags title: t(".title"), description: t(".description") %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/revenue/index.html.erb
+++ b/app/views/open_startup/revenue/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :open_graph_tags do %>
-  <%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
-<% end %>
+<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/open_startup/revenue/index.html.erb
+++ b/app/views/open_startup/revenue/index.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title"), description: t(".description")) %>
+<%= open_graph_tags title: t(".title"), description: t(".description") %>
 
 <div class="bg-gray-50 max-w-5xl mx-auto pt-12 sm:pt-16">
   <div class="text-center px-4 sm:px-6 lg:px-8">

--- a/app/views/pricing/show.html.erb
+++ b/app/views/pricing/show.html.erb
@@ -1,3 +1,5 @@
+<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: "#{t(".title_1")} #{t(".title_2")}") %>
+
 <div class="max-w-7xl mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
   <div class="pb-16 xl:flex xl:items-center xl:justify-between">
     <div>

--- a/app/views/pricing/show.html.erb
+++ b/app/views/pricing/show.html.erb
@@ -1,4 +1,4 @@
-<%= render OpenGraphTagsComponent.new(title: t(".title_og"), description: "#{t(".title_1")} #{t(".title_2")}") %>
+<%= open_graph_tags title: t(".title_og"), description: "#{t(".title_1")} #{t(".title_2")}" %>
 
 <div class="max-w-7xl mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
   <div class="pb-16 xl:flex xl:items-center xl:justify-between">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,7 @@ en:
       cta: Add my profile
       description: "%{developers_count}+ Ruby on Rails developers looking for their next gig. Juniors to seniors and everyone in between, you'll find them all here."
       title: Ruby on Rails developers
+      title_og: Hire Ruby on Rails developers
     show:
       description: Description
       edit: Edit
@@ -197,6 +198,7 @@ en:
   home:
     show:
       available_developers: Developers available now
+      description_og: railsdevs empowers independent developers available for their next gig. Stop scouring job boards and sit back as companies reach out to you first.
       get_started: Get started
       learn_more: Learn more
       more: See more developers
@@ -205,6 +207,7 @@ en:
       subtitle_3: Stop scouring job boards and sit back as companies reach out to you first.
       title_1: The reverse job board for
       title_2: Rails developers
+      title_og: The reverse job board for Ruby on Rails developers
   messages:
     form:
       help: Add your message
@@ -304,6 +307,7 @@ en:
       subtitle: Connect with independent, freelance Ruby on Rails developers who are available for work now.
       title_1: Hire Rails developers for
       title_2: "$99 a month"
+      title_og: Pricing
   pundit:
     errors:
       unauthorized: You don't have access to that.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,8 +230,6 @@ en:
     new_message: "%{sender} sent you a message."
     show:
       notice: Notification marked as read.
-  open_graph_tags_component:
-    default_description: Find Ruby on Rails developers looking for freelance, contract, and full-time work.
   open_startup:
     contributions:
       index:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -208,8 +208,6 @@ es:
       format:
         format: "%u%n"
         unit: "$"
-  open_graph_tags_component:
-    default_description: Encuentra desarrolladores Ruby on Rails buscando freelance, trabajo por contrato y tiempo completo.
   paywalled_component:
     description: Información que solo es visible con una suscripción comercial.
     title: Información provada

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -223,8 +223,6 @@ pt-BR:
       format:
         format: "%u%n"
         unit: "$"
-  open_graph_tags_component:
-    default_description: Encontre desenvolvedores Ruby on Rails buscando freelance, contratado e em tempo integral.
   open_startup:
     contributions:
       index:

--- a/test/components/developer_open_graph_meta_tags_component_test.rb
+++ b/test/components/developer_open_graph_meta_tags_component_test.rb
@@ -6,7 +6,7 @@ class DeveloperOpenGraphTagsComponentTest < ViewComponent::TestCase
 
     render_inline DeveloperOpenGraphTagsComponent.new(developer:)
 
-    assert_meta property: "og:title", content: "hero text"
+    assert_meta property: "og:title", content: "hero text · railsdevs"
     assert_meta property: "og:description", content: "bio text"
     assert_meta property: "og:url", content: "http://test.host/developers/123"
   end

--- a/test/components/open_graph_tags_component_test.rb
+++ b/test/components/open_graph_tags_component_test.rb
@@ -6,7 +6,7 @@ class OpenGraphTagsComponentTest < ViewComponent::TestCase
 
     assert_meta property: "og:type"
     assert_meta property: "og:title", content: "railsdevs"
-    assert_meta property: "og:description", content_begin_with: "Find Ruby"
+    assert_meta property: "og:description", content_begin_with: "The reverse job board"
     assert_meta property: "og:url"
     assert_meta property: "twitter:card"
   end

--- a/test/components/open_graph_tags_component_test.rb
+++ b/test/components/open_graph_tags_component_test.rb
@@ -17,7 +17,7 @@ class OpenGraphTagsComponentTest < ViewComponent::TestCase
       description: "And a custom description."
     )
 
-    assert_meta property: "og:title", content: "Custom title"
+    assert_meta property: "og:title", content: "Custom title · railsdevs"
     assert_meta property: "og:description", content: "And a custom description."
   end
 end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class DevelopersTest < ActionDispatch::IntegrationTest
+  include MetaTagsHelper
   include PagyHelper
 
   test "can view developer profiles" do
@@ -11,6 +12,12 @@ class DevelopersTest < ActionDispatch::IntegrationTest
 
     assert_select "h2", one.hero
     assert_select "h2", two.hero
+  end
+
+  test "custom meta tags are rendered" do
+    get developers_path
+    assert_title_contains "Hire Ruby on Rails developers"
+    assert_description_contains "looking for their"
   end
 
   test "developers are sorted newest first" do
@@ -103,6 +110,15 @@ class DevelopersTest < ActionDispatch::IntegrationTest
 
     assert user.developer.role_type.part_time_contract?
     assert user.developer.avatar.attached?
+  end
+
+  test "custom develper meta tags are rendered" do
+    developer = developers(:available)
+
+    get developer_path(developer)
+
+    assert_title_contains developer.hero
+    assert_description_contains developer.bio
   end
 
   test "edit with nested attributes" do

--- a/test/integration/home_test.rb
+++ b/test/integration/home_test.rb
@@ -1,10 +1,19 @@
 require "test_helper"
 
 class HomeTest < ActionDispatch::IntegrationTest
+  include MetaTagsHelper
+
   test "sees only available developer profile" do
     get root_path
 
     assert_select "h2", developers(:available).hero
     assert_select "h2", count: 1
+  end
+
+  test "custom meta tags are rendered" do
+    get root_path
+
+    assert_title_contains I18n.t("home.show.title_og")
+    assert_description_contains I18n.t("home.show.description_og")
   end
 end

--- a/test/support/helpers/meta_tags_helper.rb
+++ b/test/support/helpers/meta_tags_helper.rb
@@ -2,6 +2,14 @@ module MetaTagsHelper
   extend ActiveSupport::Concern
 
   included do
+    def assert_title_contains(content)
+      assert_select "title", text: /^#{content}/
+    end
+
+    def assert_description_contains(content)
+      assert_select "meta[property=description][content~=?]", content
+    end
+
     def assert_meta(property:, content: nil, content_begin_with: nil, content_end_with: nil, count: 1)
       selector = "meta[property='#{property}']"
 


### PR DESCRIPTION
This PR cleans up how/when Open Graph tags are rendered and tweaks the copy on a few key pages.

Current failing tests are because I can't figure out how to test `content_for` in a View Component.

### Pull request checklist

- [ ] Your code contains tests relevant for code you modified
- [ ] You have linted and tested the project with `bin/check`