### PR TITLE
Run rails app update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :development do
   # Point to GitHub until https://github.com/Shopify/erb-lint/pull/235 is released.
   gem "erb_lint", require: false, github: "Shopify/erb-lint"
   gem "hotwire-livereload"
-  gem "listen", "~> 3.3"
   gem "redis"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,6 @@ DEPENDENCIES
   inline_svg (~> 1.7)
   jsbundling-rails (~> 1.0)
   letter_opener_web
-  listen (~> 3.3)
   mailgun-ruby (~> 1.2)
   minitest-reporters (~> 1.5)
   minitest-reporters-pride_reporter (~> 0.0.2)

--- a/app/controllers/stripe/checkouts_controller.rb
+++ b/app/controllers/stripe/checkouts_controller.rb
@@ -7,7 +7,7 @@ module Stripe
         user: current_user,
         plan: params[:plan],
         success_path: stored_location_for(:user)
-      ).url
+      ).url, allow_other_host: true
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,19 +1,6 @@
 require_relative "boot"
 
-require "rails"
-# Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-# require "action_mailbox/engine"
-# require "action_text/engine"
-require "action_view/railtie"
-# require "action_cable/engine"
-require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -22,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Railsdevs
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    config.load_defaults 7.0
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,21 +5,21 @@ Rails.application.configure do
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
-  # since you don"t have to restart the web server when you make code changes.
+  # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Stores uploads to the disk in the development environment
-  config.active_storage.service = :local
-
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Enable server timing
+  config.server_timing = true
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp", "caching-dev.txt").exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
@@ -32,6 +32,14 @@ Rails.application.configure do
 
     config.cache_store = :null_store
   end
+
+  # Store uploaded files on the local file system (see config/storage.yml for options).
+  config.active_storage.service = :local
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -56,10 +64,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,6 +40,11 @@ Rails.application.configure do
   # Store uploaded files in an Amazon S3 bucket.
   config.active_storage.service = :amazon
 
+  # Mount Action Cable outside main process or domain.
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = "wss://example.com/cable"
+  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
@@ -53,18 +58,29 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "railsdevs_production"
+
+  # Use mailgun to send email.
+  config.action_mailer.delivery_method = :mailgun
+  config.action_mailer.mailgun_settings = {
+    api_key: Rails.application.credentials.dig(:mailgun, :api_key),
+    domain: Rails.application.credentials.dig(:mailgun, :domain)
+  }
+
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-
-  # Log disallowed deprecations.
-  config.active_support.disallowed_deprecation = :log
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
+  # Don't log any deprecations.
+  config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
@@ -82,13 +98,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Use mailgun to send email.
-  config.action_mailer.delivery_method = :mailgun
-  config.action_mailer.mailgun_settings = {
-    api_key: Rails.application.credentials.dig(:mailgun, :api_key),
-    domain: Rails.application.credentials.dig(:mailgun, :domain)
-  }
-
   # Devise mailer.
   config.action_mailer.default_url_options = {host: ENV["HOST"], locale: nil}
 
@@ -97,25 +106,4 @@ Rails.application.configure do
 
   # Upload sitemap to S3.
   config.upload_sitemap = true
-
-  # Inserts middleware to perform automatic connection switching.
-  # The `database_selector` hash is used to pass options to the DatabaseSelector
-  # middleware. The `delay` is used to determine how long to wait after a write
-  # to send a subsequent read to the primary.
-  #
-  # The `database_resolver` class is used by the middleware to determine which
-  # database is appropriate to use based on the time delay.
-  #
-  # The `database_resolver_context` class is used by the middleware to set
-  # timestamps for the last write to the primary. The resolver uses the context
-  # class timestamps to determine how long to wait before reading from the
-  # replica.
-  #
-  # By default Rails will store a last write timestamp in the session. The
-  # DatabaseSelector middleware is designed as such you can define your own
-  # strategy for connection switching and pass that into the middleware through
-  # these configuration options.
-  # config.active_record.database_selector = { delay: 2.seconds }
-  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  config.action_view.annotate_rendered_view_with_filenames = true
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Configure host for URL helpers.
   Rails.application.routes.default_url_options = {host: "localhost", port: 3000, locale: nil}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,12 +8,14 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = false
+  config.action_view.cache_template_loading = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
@@ -32,6 +34,19 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Store uploaded files on the local file system in a temporary directory.
+  config.active_storage.service = :test
+
+  # Devise mailer.
+  config.action_mailer.default_url_options = {host: "localhost", port: 3000, locale: nil}
+
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
+  config.action_mailer.perform_caching = false
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
@@ -41,21 +56,12 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Store test uploads on the disk in the temp folder
-  config.active_storage.service = :test
-
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Devise mailer.
-  config.action_mailer.default_url_options = {host: "localhost", port: 3000, locale: nil}
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Configure host for URL helpers.
   Rails.application.routes.default_url_options = {host: "localhost", port: 3000, locale: nil}
-
-  # Store sent emails in queue.
-  config.action_mailer.delivery_method = :test
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,25 +4,23 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
+# Rails.application.configure do
+#   config.content_security_policy do |policy|
+#     policy.default_src :self, :https
+#     policy.font_src    :self, :https, :data
+#     policy.img_src     :self, :https, :data
+#     policy.object_src  :none
+#     policy.script_src  :self, :https
+#     policy.style_src   :self, :https
+#     # Specify URI for violation reports
+#     # policy.report_uri "/csp-violation-report-endpoint"
+#   end
+#
+#   # Generate session nonces for permitted importmap and inline scripts
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#   config.content_security_policy_nonce_directives = %w(script-src)
+#
+#   # Report CSP violations to a specified URI. See:
+#   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+#   # config.content_security_policy_report_only = true
 # end
-
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
-
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# Configure sensitive parameters which will be filtered from the log file.
+# Configure parameters to be filtered from the log file. Use this to limit dissemination of
+# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
+# notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -4,8 +4,8 @@
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, "\1en"
-#   inflect.singular /^(ox)en/i, "\1"
+#   inflect.plural /^(ox)$/i, "\\1en"
+#   inflect.singular /^(ox)en/i, "\\1"
 #   inflect.irregular "person", "people"
 #   inflect.uncountable %w( fish sheep )
 # end

--- a/db/migrate/20220316124157_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20220316124157_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,0 +1,18 @@
+# This migration comes from active_storage (originally 20190112182829)
+class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name)
+      add_column :active_storage_blobs, :service_name, :string
+
+      if (configured_service = ActiveStorage::Blob.service.name)
+        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+  end
+end

--- a/db/migrate/20220316124158_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20220316124158_create_active_storage_variant_records.active_storage.rb
@@ -1,0 +1,26 @@
+# This migration comes from active_storage (originally 20191206030411)
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary key
+    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
+      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+      t.string :variation_digest, null: false
+
+      t.index %i[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
+  end
+
+  def blobs_primary_key_type
+    pkey_name = connection.primary_key(:active_storage_blobs)
+    pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+    pkey_column.bigint? ? :bigint : pkey_column.type
+  end
+end

--- a/db/migrate/20220316124159_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20220316124159_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,0 +1,6 @@
+# This migration comes from active_storage (originally 20211119233751)
+class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:active_storage_blobs, :checksum, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_16_124159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -31,8 +31,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.text "metadata"
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -55,8 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.bigint "user_id"
     t.string "name", null: false
     t.string "company", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "bio", null: false
     t.integer "developer_notifications", default: 0, null: false
     t.index ["user_id"], name: "index_businesses_on_user_id"
@@ -65,10 +65,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
   create_table "conversations", force: :cascade do |t|
     t.bigint "developer_id"
     t.bigint "business_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "developer_blocked_at", precision: 6
-    t.datetime "business_blocked_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "developer_blocked_at"
+    t.datetime "business_blocked_at"
     t.index ["business_id"], name: "index_conversations_on_business_id"
     t.index ["developer_id"], name: "index_conversations_on_developer_id"
   end
@@ -82,8 +82,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "website"
     t.string "github"
     t.string "twitter"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.string "linkedin"
     t.integer "search_status"
@@ -115,8 +115,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "sender_type"
     t.bigint "sender_id"
     t.text "body", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "body_html", null: false
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["sender_type", "sender_id"], name: "index_messages_on_sender"
@@ -127,9 +127,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.bigint "recipient_id", null: false
     t.string "type", null: false
     t.jsonb "params"
-    t.datetime "read_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["read_at"], name: "index_notifications_on_read_at"
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient"
   end
@@ -139,8 +139,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "description", null: false
     t.string "url"
     t.decimal "amount", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "open_startup_expenses", force: :cascade do |t|
@@ -148,15 +148,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "description", null: false
     t.string "url"
     t.decimal "amount", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "open_startup_metrics", force: :cascade do |t|
     t.date "occurred_on", null: false
     t.jsonb "data", default: {}, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "open_startup_monthly_balances", force: :cascade do |t|
@@ -164,27 +164,27 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.decimal "revenue", null: false
     t.decimal "expenses", null: false
     t.decimal "contributions", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "open_startup_revenue", force: :cascade do |t|
     t.date "occurred_on", null: false
     t.string "description", null: false
     t.decimal "amount", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "open_startup_stripe_transactions", force: :cascade do |t|
     t.string "stripe_id", null: false
     t.decimal "amount", null: false
-    t.datetime "created", precision: 6, null: false
+    t.datetime "created", null: false
     t.string "description", null: false
     t.decimal "fee", null: false
     t.string "transaction_type", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["stripe_id"], name: "index_open_startup_stripe_transactions_on_stripe_id"
     t.index ["transaction_type"], name: "index_open_startup_stripe_transactions_on_transaction_type"
   end
@@ -195,8 +195,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "url"
     t.decimal "amount", null: false
     t.integer "transaction_type", default: 1, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "pay_charges", force: :cascade do |t|
@@ -209,8 +209,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.integer "amount_refunded"
     t.jsonb "metadata"
     t.jsonb "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["customer_id", "processor_id"], name: "index_pay_charges_on_customer_id_and_processor_id", unique: true
     t.index ["subscription_id"], name: "index_pay_charges_on_subscription_id"
   end
@@ -222,9 +222,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "processor_id"
     t.boolean "default"
     t.jsonb "data"
-    t.datetime "deleted_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["owner_type", "owner_id", "deleted_at", "default"], name: "pay_customer_owner_index"
     t.index ["processor", "processor_id"], name: "index_pay_customers_on_processor_and_processor_id", unique: true
   end
@@ -236,8 +236,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "processor_id"
     t.boolean "default"
     t.jsonb "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["owner_type", "owner_id", "processor"], name: "index_pay_merchants_on_owner_type_and_owner_id_and_processor"
   end
 
@@ -247,8 +247,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.boolean "default"
     t.string "type"
     t.jsonb "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["customer_id", "processor_id"], name: "index_pay_payment_methods_on_customer_id_and_processor_id", unique: true
   end
 
@@ -259,13 +259,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "processor_plan", null: false
     t.integer "quantity", default: 1, null: false
     t.string "status", null: false
-    t.datetime "trial_ends_at", precision: 6
-    t.datetime "ends_at", precision: 6
+    t.datetime "trial_ends_at"
+    t.datetime "ends_at"
     t.decimal "application_fee_percent", precision: 8, scale: 2
     t.jsonb "metadata"
     t.jsonb "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["customer_id", "processor_id"], name: "index_pay_subscriptions_on_customer_id_and_processor_id", unique: true
   end
 
@@ -273,8 +273,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "processor"
     t.string "event_type"
     t.jsonb "event"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "role_levels", force: :cascade do |t|
@@ -284,8 +284,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.boolean "senior"
     t.boolean "principal"
     t.boolean "c_level"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["developer_id"], name: "index_role_levels_on_developer_id", unique: true
   end
 
@@ -294,8 +294,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.boolean "part_time_contract"
     t.boolean "full_time_contract"
     t.boolean "full_time_employment"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["developer_id"], name: "index_role_types_on_developer_id", unique: true
   end
 
@@ -303,14 +303,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_15_031550) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: 6
-    t.datetime "remember_created_at", precision: 6
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
     t.string "confirmation_token"
-    t.datetime "confirmed_at", precision: 6
-    t.datetime "confirmation_sent_at", precision: 6
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/test/components/timezone_component_test.rb
+++ b/test/components/timezone_component_test.rb
@@ -11,13 +11,16 @@ class TimeZoneComponentTest < ViewComponent::TestCase
 
   test "it renders the human readable time zone" do
     render(time_zone: "America/Los_Angeles", utc_offset: PACIFIC_UTC_OFFSET)
-    assert_selector("span", text: "Pacific Time (US & Canada) (GMT-8)")
+    assert_text "Pacific Time (US & Canada)"
+    assert_text "GMT-8"
 
     render(time_zone: "Europe/Paris", utc_offset: 3600)
-    assert_selector("span", text: "Paris (GMT+1)")
+    assert_text "Paris"
+    assert_text "GMT+1"
 
     render(time_zone: "Asia/Kolkata", utc_offset: 19800)
-    assert_selector("span", text: "Chennai (GMT+5.5)")
+    assert_text "Chennai"
+    assert_text "GMT+5.5"
   end
 
   def render(time_zone:, utc_offset:)

--- a/test/components/timezone_component_test.rb
+++ b/test/components/timezone_component_test.rb
@@ -11,16 +11,13 @@ class TimeZoneComponentTest < ViewComponent::TestCase
 
   test "it renders the human readable time zone" do
     render(time_zone: "America/Los_Angeles", utc_offset: PACIFIC_UTC_OFFSET)
-    assert_text "Pacific Time (US & Canada)"
-    assert_text "GMT-8"
+    assert_selector("span", text: "Pacific Time (US & Canada) (GMT-8)")
 
     render(time_zone: "Europe/Paris", utc_offset: 3600)
-    assert_text "Paris"
-    assert_text "GMT+1"
+    assert_selector("span", text: "Paris (GMT+1)")
 
     render(time_zone: "Asia/Kolkata", utc_offset: 19800)
-    assert_text "Chennai"
-    assert_text "GMT+5.5"
+    assert_selector("span", text: "Chennai (GMT+5.5)")
   end
 
   def render(time_zone:, utc_offset:)


### PR DESCRIPTION
Turns out we were still using Rails 6.1 framework defaults! This PR runs `rails app:update`, runs the migrations (with new `precision:` syntax), and fixes a test.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`