### PR TITLE
improve system tests for filters by matching against regex instead of string

### DIFF
--- a/test/system/filters_test.rb
+++ b/test/system/filters_test.rb
@@ -6,7 +6,7 @@ class FiltersTest < ApplicationSystemTestCase
     find(:css, "#sort button[type='button']").click
     find(:css, "#sort button[type='submit'][value='availability']").click
 
-    assert_current_path developers_path(sort: :availability)
+    assert_current_path /sort=availability/
   end
 
   test "developers newest sort click adds sort param" do
@@ -14,7 +14,7 @@ class FiltersTest < ApplicationSystemTestCase
     find(:css, "#sort button[type='button']").click
     find(:css, "#sort button[type='submit'][value='newest']").click
 
-    assert_current_path developers_path(sort: :newest)
+    assert_current_path /sort=newest/
   end
 
   test "developers sort order is persisted with work preferences filters" do
@@ -23,7 +23,8 @@ class FiltersTest < ApplicationSystemTestCase
     find(:css, "[name='include_not_interested']").set(true)
     find(:css, "#desktop-work-preferences-filters button[name='sort']").click
 
-    assert_current_path developers_path(sort: :newest, include_not_interested: 1)
+    assert_current_path /sort=newest/
+    assert_current_path /include_not_interested=1/
   end
 
   test "applying multiple filters to developers" do
@@ -32,17 +33,19 @@ class FiltersTest < ApplicationSystemTestCase
     find(:css, "#sort button[type='button']").click
     find(:css, "#sort button[type='submit'][value='availability']").click
 
-    assert_current_path developers_path(sort: :availability)
+    assert_current_path /sort=availability/
 
     find(:css, "#desktop-work-preferences-filters button[type='button']").click
     find(:css, "[name='include_not_interested']").set(true)
     find(:css, "#desktop-work-preferences-filters button[name='sort']").click
 
-    assert_current_path developers_path(sort: :availability, include_not_interested: 1)
+    assert_current_path /sort=availability/
+    assert_current_path /include_not_interested=1/
 
     find(:css, "#sort button[type='button']").click
     find(:css, "#sort button[type='submit'][value='newest']").click
 
-    assert_current_path developers_path(sort: :newest, include_not_interested: 1)
+    assert_current_path /sort=newest/
+    assert_current_path /include_not_interested=1/
   end
 end


### PR DESCRIPTION
This PR is aiming to improve the assertions of filters system test by matching the `current_path` against a regex of expected query param instead of whole string. More information why this change is needed can be found [here](https://github.com/joemasilotti/railsdevs.com/discussions/338).
<!-- Description of pull request linking to any relevant issues. -->

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`

