### PR TITLE
Add instructions to start Postgresql and Redis servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ You will also need Google Chrome installed to run the system tests.
 
 ### Initial setup
 
+Start Postgresql server.
+
+```bash
+brew services start postgresql
+```
+
+Start Redis server.
+
+```bash
+brew services start redis
+```
+
 An installation script is included with the repository that will automatically get the application setup.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You will also need Google Chrome installed to run the system tests.
 
 ### Initial setup
 
-Start Postgresql server.
+Start PostgreSQL server.
 
 ```bash
 brew services start postgresql

--- a/bin/setup
+++ b/bin/setup
@@ -45,10 +45,4 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
-
-  puts "\n== Next steps =="
-  puts "Start Postgres:"
-  puts "  brew services restart postgresql"
-  puts "Start Redis:"
-  puts "  brew services restart redis"
 end


### PR DESCRIPTION
I tried to set up the local development environment using the setup instructions. The `bin/setup` script failed as the database and Redis servers weren't running. This pull request adds the instructions to start those before running the script. 

Note: This is my first time contributing to any open source project. Please let me know if I missed something or anything that needs to be corrected. 

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`
- [x] You have added significant changes and product updates to the [changelog](CHANGELOG.md)
