### PR TITLE
Fix OpenStartup::ReportingTest (Timezone issue)

### DIFF
--- a/test/models/open_startup/reporting_test.rb
+++ b/test/models/open_startup/reporting_test.rb
@@ -117,11 +117,11 @@ class OpenStartup::ReportingTest < ActiveSupport::TestCase
   end
 
   def january
-    (today - 1.day).to_time.to_i
+    (today - 1.day).to_time(:utc).to_i
   end
 
   def february
-    today.to_time.to_i
+    today.to_time(:utc).to_i
   end
 
   def today


### PR DESCRIPTION
Likely fixes the same testing issue described in [#320](https://github.com/joemasilotti/railsdevs.com/pull/320#issuecomment-1065902204)

#to_time, by default, uses the `:local` time (varies per machine),
has timezone data. `#to_i` offsets this when converting to integer… 
but the timezone information at this point is lost!
	
`OpenStartup::Reporting#create_or_update_transaction`
doesn't convert it back to the correct timezone	

Result: if you’re living on the right side of UTC (starting from UTC+1),
some transactions appear on january reports instead of february

Solution: remove test dependency to any dev machine's
`:local` time and `use to_time(:utc)` instead