### PR TITLE
Add keyboard shortcut affordance to message form

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,6 +12,9 @@ application.register("file-upload", FileUploadController)
 import FormController from "./form_controller.js"
 application.register("form", FormController)
 
+import KeyboardShortcutController from "./keyboard_shortcut_controller.js"
+application.register("keyboard-shortcut", KeyboardShortcutController)
+
 import PageScrollController from "./page_scroll_controller.js"
 application.register("page-scroll", PageScrollController)
 

--- a/app/javascript/controllers/keyboard_shortcut_controller.js
+++ b/app/javascript/controllers/keyboard_shortcut_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["mac", "windows"]
+  static classes = ["visibility"]
+
+  connect() {
+    if (navigator.userAgent.indexOf("Mac") != -1) {
+      this.macTarget.classList.remove(this.visibilityClasses)
+      this.element.classList.remove(this.visibilityClasses)
+    } else if (navigator.userAgent.indexOf("Windows") != -1) {
+      this.windowsTarget.classList.remove(this.visibilityClasses)
+      this.element.classList.remove(this.visibilityClasses)
+    }
+  }
+}

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -4,7 +4,15 @@
     <%= form.text_area :body, rows: 4, required: true, autofocus: true, data: {action: "keydown->form#submit"}, class: field_classes(form, :body) %>
   </div>
 
-  <div class="py-2 flex justify-end">
+  <div class="py-2 flex space-x-4 justify-end items-baseline">
+    <div class="hidden sm:block">
+      <div data-controller="keyboard-shortcut" data-keyboard-shortcut-visibility-class="hidden" class="hidden text-xs text-gray-500 font-semibold flex space-x-2 items-baseline">
+        <span data-keyboard-shortcut-target="mac" class="hidden font-mono">&#x2318</span>
+        <span data-keyboard-shortcut-target="windows" class="hidden font-mono">Ctrl</span>
+        <span class="font-mono"> + Enter</span>
+      </div>
+    </div>
+
     <div class="shrink-0">
       <%= render SubmitButtonComponent.new(text: t(".submit"), disable_with: t(".sending")) %>
     </div>


### PR DESCRIPTION
This PR adds a little helper text noting the keyboard shortcut for the messaging form.

It starts off hidden and unhides depending on operating system (see screenshots below). The text remains hidden on devices smaller than "small" on Tailwind CSS.

<img width="663" alt="image" src="https://user-images.githubusercontent.com/2092156/163576128-4c2fb03e-403c-4e84-9c4e-6074ebbb6744.png">

<img width="659" alt="image" src="https://user-images.githubusercontent.com/2092156/163576158-bf925f2f-3a7d-4991-94a9-13cc12d21e92.png">

Closes #344.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`
- [ ] You have added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
