### PR TITLE
add index for searching developers by hero and bio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     services:
       db:
-        image: postgres:10.13
+        image: postgres:12.10
         ports: ["5432:5432"]
         env:
           POSTGRES_USER: postgres

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -30,7 +30,7 @@ class Developer < ApplicationRecord
   validates :location, presence: true, on: :create
   validates :name, presence: true
 
-  pg_search_scope :filter_by_search_query, against: [:bio, :hero]
+  pg_search_scope :filter_by_search_query, against: [:bio, :hero], using: {tsearch: {tsvector_column: :textsearchable_index_col}}
 
   scope :filter_by_role_types, ->(role_types) do
     RoleType::TYPES.filter_map { |type|

--- a/db/migrate/20220416144523_add_index_for_searchable_fields_in_developers.rb
+++ b/db/migrate/20220416144523_add_index_for_searchable_fields_in_developers.rb
@@ -1,0 +1,16 @@
+class AddIndexForSearchableFieldsInDevelopers < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      ALTER TABLE developers
+        ADD COLUMN textsearchable_index_col tsvector
+          GENERATED ALWAYS AS (to_tsvector('simple', coalesce(hero, '') || ' ' || coalesce(bio, ''))) STORED;
+    SQL
+
+    add_index :developers, :textsearchable_index_col, using: :gin, name: :textsearchable_index
+  end
+
+  def down
+    remove_index :developers, name: :textsearchable_index
+    remove_column :developers, :textsearchable_index_col
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_16_124159) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_16_144523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,6 +91,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_16_124159) do
     t.integer "preferred_max_hourly_rate"
     t.integer "preferred_min_salary"
     t.integer "preferred_max_salary"
+    t.virtual "textsearchable_index_col", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((COALESCE(hero, ''::character varying))::text || ' '::text) || COALESCE(bio, ''::text)))", stored: true
+    t.index ["textsearchable_index_col"], name: "textsearchable_index", using: :gin
     t.index ["user_id"], name: "index_developers_on_user_id"
   end
 


### PR DESCRIPTION
# Description

This PR is aiming to add an index to speed up the searching of developers by either bio or hero. Mostly I have followed the [related docs of PostgreSQL](https://www.postgresql.org/docs/current/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX) to implement this functionality.

Basically, I have created a new column of type `tsvector` to hold the output of `to_tsvector` function, and then added `GIN` index to that column.

As that newly added column depends upon the values of `bio` and `hero` so we need to make sure whenever these values get changed we also update this `tsvector` column. For that purpose, I have utilized the [generated columns](https://www.postgresql.org/docs/current/ddl-generated-columns.html#:~:text=A%20stored%20generated%20column%20is,computed%20when%20it%20is%20read.) feature of PostgreSQL.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] Your code contains tests relevant for code you modified
- [x] You have linted and tested the project with `bin/check`
- [x] You have added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
