### PR TITLE
Unignore i18n tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,9 +216,10 @@ GEM
     http-form_data (2.3.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.36)
+    i18n-tasks (1.0.9)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
+      better_html (~> 1.0)
       erubi
       highline (>= 2.0.0)
       i18n

--- a/app/components/availability_component.html.erb
+++ b/app/components/availability_component.html.erb
@@ -2,6 +2,9 @@
   <%= availability_icon %>
 
   <span class="ml-2 text-sm font-medium <%= "text-green-700" if available? %>">
+    <%# i18n-tasks-use t('availability_component.in_future_html') %>
+    <%# i18n-tasks-use t('availability_component.now_html') %>
+    <%# i18n-tasks-use t('availability_component.unspecified_html') %>
     <%= t(".#{developer.availability_status}_html", date: date, date_in_words: date_in_words) %>
   </span>
 </div>

--- a/app/components/developer_query_component.rb
+++ b/app/components/developer_query_component.rb
@@ -23,6 +23,9 @@ class DeveloperQueryComponent < ApplicationComponent
   end
 
   def role_types
+    # i18n-tasks-use t('activerecord.attributes.role_type.full_time_contract')
+    # i18n-tasks-use t('activerecord.attributes.role_type.full_time_employment')
+    # i18n-tasks-use t('activerecord.attributes.role_type.part_time_contract')
     RoleType::TYPES.map { |role| [role, RoleType.human_attribute_name(role)] }
   end
 

--- a/app/components/developer_query_component.rb
+++ b/app/components/developer_query_component.rb
@@ -31,6 +31,11 @@ class DeveloperQueryComponent < ApplicationComponent
   end
 
   def role_levels
+    # i18n-tasks-use t('activerecord.attributes.role_level.c_level')
+    # i18n-tasks-use t('activerecord.attributes.role_level.junior')
+    # i18n-tasks-use t('activerecord.attributes.role_level.mid')
+    # i18n-tasks-use t('activerecord.attributes.role_level.principal')
+    # i18n-tasks-use t('activerecord.attributes.role_level.senior')
     RoleLevel::TYPES.map { |role| [role, RoleLevel.human_attribute_name(role)] }
   end
 

--- a/app/components/role_level_component.rb
+++ b/app/components/role_level_component.rb
@@ -14,6 +14,11 @@ class RoleLevelComponent < ApplicationComponent
   end
 
   def humanize(attribute)
+    # i18n-tasks-use t('activerecord.attributes.role_level.c_level')
+    # i18n-tasks-use t('activerecord.attributes.role_level.junior')
+    # i18n-tasks-use t('activerecord.attributes.role_level.mid')
+    # i18n-tasks-use t('activerecord.attributes.role_level.principal')
+    # i18n-tasks-use t('activerecord.attributes.role_level.senior')
     RoleLevel.human_attribute_name(attribute)
   end
 

--- a/app/components/search_status_component.rb
+++ b/app/components/search_status_component.rb
@@ -22,6 +22,9 @@ class SearchStatusComponent < ApplicationComponent
   end
 
   def humanize(enum_value)
+    # i18n-tasks-use t('activerecord.attributes.developer/search_status.actively_looking')
+    # i18n-tasks-use t('activerecord.attributes.developer/search_status.not_interested')
+    # i18n-tasks-use t('activerecord.attributes.developer/search_status.open')
     Developer.human_attribute_name "search_status.#{enum_value}"
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -23,6 +23,7 @@ class Location < ApplicationRecord
 
   def valid_coordinates
     if latitude.blank? || longitude.blank?
+      # i18n-tasks-use t('activerecord.errors.models.location.invalid_coordinates')
       errors.add(:city, :invalid_coordinates)
     end
   end

--- a/app/views/open_startup/contributions/index.html.erb
+++ b/app/views/open_startup/contributions/index.html.erb
@@ -63,6 +63,7 @@
               <% @contributions.each do |contribution| %>
                 <tr>
                   <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    <%# i18n-tasks-use t('date.formats.month_year')%>
                     <%= l(contribution.occurred_on, format: :month_year) %>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/app/views/open_startup/dashboard/show.html.erb
+++ b/app/views/open_startup/dashboard/show.html.erb
@@ -36,6 +36,10 @@
                 <%= t(".visitors") %>
               </dt>
               <dd class="order-1 text-5xl font-extrabold text-gray-600">
+                <%# i18n-tasks-use t('size.billion') %>
+                <%# i18n-tasks-use t('size.million') %>
+                <%# i18n-tasks-use t('size.thousand') %>
+                <%# i18n-tasks-use t('size.unit') %>
                 <%= number_to_human(@metric.visitors, units: :size) %>
               </dd>
             <% end %>

--- a/app/views/open_startup/dashboard/show.html.erb
+++ b/app/views/open_startup/dashboard/show.html.erb
@@ -73,6 +73,7 @@
               <% @monthly_balances.each do |monthly_balance| %>
                 <tr>
                   <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    <%# i18n-tasks-use t('date.formats.month_year')%>
                     <%= l(monthly_balance.occurred_on, format: :month_year) %>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-500">

--- a/app/views/open_startup/expenses/index.html.erb
+++ b/app/views/open_startup/expenses/index.html.erb
@@ -34,6 +34,7 @@
               <% @expenses.each do |expense| %>
                 <tr>
                   <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    <%# i18n-tasks-use t('date.formats.month_year')%>
                     <%= l(expense.occurred_on, format: :month_year) %>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/app/views/open_startup/revenue/index.html.erb
+++ b/app/views/open_startup/revenue/index.html.erb
@@ -34,6 +34,7 @@
               <% @revenue.each do |revenue| %>
                 <tr>
                   <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    <%# i18n-tasks-use t('date.formats.month_year')%>
                     <%= l(revenue.occurred_on, format: :month_year) %>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,6 +2,9 @@
   <% content_for :flash do %>
     <%= render ToastMessageComponent.new(icon: "x_circle", color: :red, messages_tag: :ul) do |c| %>
       <%= c.title do %>
+        <%# i18n-tasks-use t('activerecord.models.business') %>
+        <%# i18n-tasks-use t('activerecord.models.developer') %>
+        <%# i18n-tasks-use t('activerecord.models.user') %>
         <%= I18n.t "errors.messages.not_saved", count: resource.errors.count, resource: resource.class.model_name.human.downcase %>
       <% end %>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -87,6 +87,15 @@ search:
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
   # strict: true
 
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
   ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -120,7 +120,6 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
 - 'activerecord.attributes.*' # 46 unused keys
-- 'activerecord.models.*' # 3
 - 'availability_component.*' # 3
 - 'errors.messages.*' # 8
 - 'size.{billion,million,thousand,unit}' # 4

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -111,7 +111,6 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
 - 'activerecord.attributes.*' # 46 unused keys
-- 'activerecord.errors.models.location.invalid_coordinates' # 1
 - 'activerecord.models.*' # 3
 - 'availability_component.*' # 3
 - 'errors.messages.*' # 8

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -121,7 +121,6 @@ ignore_missing:
 ## Consider these keys used:
 ignore_unused:
 - 'activerecord.attributes.*' # 46 unused keys
-- 'availability_component.*' # 3
 - 'errors.messages.*' # 8
 - 'size.{billion,million,thousand,unit}' # 4
 - '{devise}.*' #74

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -122,7 +122,6 @@ ignore_missing:
 ignore_unused:
 - 'activerecord.attributes.*' # 46 unused keys
 - 'errors.messages.*' # 8
-- 'size.{billion,million,thousand,unit}' # 4
 - '{devise}.*' #74
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -87,16 +87,6 @@ search:
   ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
   # strict: true
 
-  ## Allows adding ast_matchers for finding translations using the AST-scanners
-  ## The available matchers are:
-  ## - RailsModelMatcher
-  ##     Matches ActiveRecord translations like
-  ##     User.human_attribute_name(:email) and User.model_name.human
-  ##
-  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
-  <% require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher' %>
-  <% I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
-
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
   ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -110,14 +110,13 @@ ignore_missing:
 
 ## Consider these keys used:
 ignore_unused:
-- 'activerecord.attributes.*'
-- 'activerecord.errors.models.location.invalid_coordinates'
-- 'activerecord.models.*'
-- 'availability_component.*'
-- 'date.formats.month_year' # l helper is not captured
-- 'errors.messages.*'
-- 'size.{billion,million,thousand,unit}'
-- '{devise}.*'
+- 'activerecord.attributes.*' # 46 unused keys
+- 'activerecord.errors.models.location.invalid_coordinates' # 1
+- 'activerecord.models.*' # 3
+- 'availability_component.*' # 3
+- 'errors.messages.*' # 8
+- 'size.{billion,million,thousand,unit}' # 4
+- '{devise}.*' #74
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -94,7 +94,8 @@ search:
   ##     User.human_attribute_name(:email) and User.model_name.human
   ##
   ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
-  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+  <% require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher' %>
+  <% I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.


### PR DESCRIPTION
Kickstarts #313 

From 140 -> 117 unused keys (if I remove all ignore_unused in i18n-tasks.yml)

Leaves the activerecord and devise-related translations ignored by i18n-tasks.