### PR TITLE
Account for free plans

### DIFF
--- a/app/components/nav_bar/user_component.rb
+++ b/app/components/nav_bar/user_component.rb
@@ -60,7 +60,7 @@ module NavBar
     end
 
     def customer?
-      user.payment_processor.present?
+      user.payment_processor&.respond_to?(:billing_portal)
     end
   end
 end

--- a/app/models/business_subscription.rb
+++ b/app/models/business_subscription.rb
@@ -16,6 +16,8 @@ module BusinessSubscription
       PartTime.new
     elsif Legacy.new.plan == price
       Legacy.new
+    elsif Free.new.plan == price
+      Free.new
     else
       raise UnknownPrice.new
     end

--- a/app/models/business_subscription/free.rb
+++ b/app/models/business_subscription/free.rb
@@ -1,0 +1,16 @@
+module BusinessSubscription
+  class Free
+    def price_id
+      nil
+    end
+    alias_method :plan, :price_id
+
+    def price
+      0
+    end
+
+    def name
+      "Free"
+    end
+  end
+end

--- a/test/models/business_subscription_test.rb
+++ b/test/models/business_subscription_test.rb
@@ -15,6 +15,7 @@ class BusinessSubscriptionTest < ActiveSupport::TestCase
     assert_instance_of FullTime, BusinessSubscription.from(price_ids[:full_time_plan])
     assert_instance_of Legacy, BusinessSubscription.from(price_ids[:legacy_plan])
     assert_instance_of PartTime, BusinessSubscription.from(price_ids[:part_time_plan])
+    assert_instance_of Free, BusinessSubscription.from(nil)
 
     assert_raises UnknownPrice do
       BusinessSubscription.from("invalid_price")


### PR DESCRIPTION
When sending a notification to admins about a conversation being started the plan level/name of the sender is displayed. Businesses on a free plan (me!) were causing an exception to be raised because they don't have a price associated with the plan.

Also, clicking Billing with a free plan was blowing up because the plan is set free a [fake payment processor](https://github.com/pay-rails/pay/blob/master/docs/fake_processor/1_overview.md) blows up because there is not Stripe Dashboard. This PR removes the link for those users.

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
