### PR TITLE
Move email/notification sending from callbacks to explicit methods

### DIFF
--- a/app/controllers/admin/invisiblizes_controller.rb
+++ b/app/controllers/admin/invisiblizes_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class InvisiblizesController < ApplicationController
     def create
-      Developer.find(params[:developer_id]).invisiblize!
+      Developer.find(params[:developer_id]).invisiblize_and_notify!
       redirect_to developers_path, notice: t(".created")
     end
   end

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -10,7 +10,7 @@ class BusinessesController < ApplicationController
     @business = current_user.build_business
     @business.assign_attributes(permitted_attributes(@business))
 
-    if @business.save
+    if @business.save_and_notify
       url = stored_location_for(:user) || developers_path
       event = Analytics::Event.added_business_profile(url)
       redirect_to event, notice: t(".created")

--- a/app/controllers/cold_messages_controller.rb
+++ b/app/controllers/cold_messages_controller.rb
@@ -11,7 +11,7 @@ class ColdMessagesController < ApplicationController
 
   def create
     message = Message.new(message_params.merge(conversation:, sender: business))
-    if message.save
+    if message.save_and_notify(cold_message: true)
       redirect_to message.conversation
     else
       @cold_message = cold_message(message)

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -14,7 +14,7 @@ class DevelopersController < ApplicationController
   def create
     @developer = current_user.build_developer(developer_params)
 
-    if @developer.save
+    if @developer.save_and_notify
       url = developer_path(@developer)
       event = Analytics::Event.added_developer_profile(url)
       redirect_to event, notice: t(".created")

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,7 @@ class MessagesController < ApplicationController
     authorize @message, policy_class: MessagingPolicy
     authorize @message, :messageable?, policy_class: SubscriptionPolicy
 
-    if @message.save
+    if @message.save_and_notify
       respond_to do |format|
         format.turbo_stream { @new_message = conversation.messages.build }
         format.html { redirect_to conversation }

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -1,5 +1,6 @@
 class Business < ApplicationRecord
   include Avatarable
+  include Businesses::Notifications
 
   enum :developer_notifications, %i[no daily weekly], default: :no, suffix: true
 
@@ -12,16 +13,4 @@ class Business < ApplicationRecord
   validates :company, presence: true
   validates :bio, presence: true
   validates :developer_notifications, inclusion: {in: developer_notifications.keys}
-
-  after_create_commit :send_admin_notification, :send_welcome_email
-
-  private
-
-  def send_admin_notification
-    NewBusinessNotification.with(business: self).deliver_later(User.admin)
-  end
-
-  def send_welcome_email
-    BusinessMailer.with(business: self).welcome_email.deliver_later
-  end
 end

--- a/app/models/concerns/businesses/notifications.rb
+++ b/app/models/concerns/businesses/notifications.rb
@@ -1,0 +1,21 @@
+module Businesses
+  module Notifications
+    def save_and_notify
+      if save
+        send_admin_notification
+        send_welcome_email
+        true
+      end
+    end
+
+    private
+
+    def send_admin_notification
+      NewBusinessNotification.with(business: self).deliver_later(User.admin)
+    end
+
+    def send_welcome_email
+      BusinessMailer.with(business: self).welcome_email.deliver_later
+    end
+  end
+end

--- a/app/models/concerns/developers/notifications.rb
+++ b/app/models/concerns/developers/notifications.rb
@@ -1,0 +1,30 @@
+module Developers
+  module Notifications
+    def save_and_notify
+      if save
+        send_admin_notification
+        send_welcome_email
+        true
+      end
+    end
+
+    def invisiblize_and_notify!
+      invisible!
+      send_invisiblize_notification
+    end
+
+    private
+
+    def send_admin_notification
+      NewDeveloperProfileNotification.with(developer: self).deliver_later(User.admin)
+    end
+
+    def send_welcome_email
+      DeveloperMailer.with(developer: self).welcome_email.deliver_later
+    end
+
+    def send_invisiblize_notification
+      InvisiblizeDeveloperNotification.with(developer: self).deliver_later(user)
+    end
+  end
+end

--- a/app/models/concerns/messages/notifications.rb
+++ b/app/models/concerns/messages/notifications.rb
@@ -1,0 +1,21 @@
+module Messages
+  module Notifications
+    def save_and_notify(cold_message: false)
+      if save
+        send_recipient_notification
+        send_admin_notification if cold_message
+        true
+      end
+    end
+
+    private
+
+    def send_recipient_notification
+      NewMessageNotification.with(message: self, conversation:).deliver_later(recipient.user)
+    end
+
+    def send_admin_notification
+      NewConversationNotification.with(conversation: self).deliver_later(User.admin)
+    end
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -11,8 +11,6 @@ class Conversation < ApplicationRecord
   scope :blocked, -> { where.not(developer_blocked_at: nil).or(Conversation.where.not(business_blocked_at: nil)) }
   scope :visible, -> { where(developer_blocked_at: nil, business_blocked_at: nil) }
 
-  after_create_commit :send_admin_notification
-
   def other_recipient(user)
     developer == user.developer ? business : developer
   end
@@ -34,10 +32,6 @@ class Conversation < ApplicationRecord
   end
 
   private
-
-  def send_admin_notification
-    NewConversationNotification.with(conversation: self).deliver_later(User.admin)
-  end
 
   def developer_replied?
     messages.from_developer.any?

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,6 +1,7 @@
 class Developer < ApplicationRecord
   include Availability
   include Avatarable
+  include Developers::Notifications
   include HasSocialProfiles
   include PgSearch::Model
 
@@ -54,8 +55,6 @@ class Developer < ApplicationRecord
   scope :visible, -> { where.not(search_status: :invisible).or(where(search_status: nil)) }
   scope :featured, -> { where("featured_at >= ?", 1.week.ago).order(featured_at: :desc) }
 
-  after_create_commit :send_admin_notification, :send_welcome_email
-
   def visible?
     !invisible?
   end
@@ -81,26 +80,7 @@ class Developer < ApplicationRecord
       available_on.blank?
   end
 
-  def invisiblize!
-    invisible!
-    send_invisiblize_notification
-  end
-
   def feature!
     touch(:featured_at)
-  end
-
-  private
-
-  def send_admin_notification
-    NewDeveloperProfileNotification.with(developer: self).deliver_later(User.admin)
-  end
-
-  def send_welcome_email
-    DeveloperMailer.with(developer: self).welcome_email.deliver_later
-  end
-
-  def send_invisiblize_notification
-    InvisiblizeDeveloperNotification.with(developer: self).deliver_later(user)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
+  include Messages::Notifications
+
   FORMAT = AutoHtml::Pipeline.new(
     AutoHtml::HtmlEscape.new,
     AutoHtml::Link.new(target: "_blank"),
@@ -14,8 +16,6 @@ class Message < ApplicationRecord
 
   validates :body, presence: true
   validates :hiring_fee_agreement, acceptance: true
-
-  after_create_commit :send_recipient_notification
 
   scope :from_developer, -> { where(sender_type: Developer.name) }
 
@@ -34,11 +34,5 @@ class Message < ApplicationRecord
   def body=(text)
     super(text)
     self[:body_html] = FORMAT.call(text)
-  end
-
-  private
-
-  def send_recipient_notification
-    NewMessageNotification.with(message: self, conversation:).deliver_later(recipient.user)
   end
 end

--- a/db/seeds/developers.rb
+++ b/db/seeds/developers.rb
@@ -17,7 +17,7 @@ developer = SeedsHelper.create_developer!("invisible", {
   hero: "Invisible developer",
   location: SeedsHelper.locations[:new_york]
 })
-developer.invisiblize! unless developer.invisible?
+developer.invisible! unless developer.invisible?
 
 # Junior developer
 SeedsHelper.create_developer!("junior", {

--- a/test/components/nav_bar/user_component_test.rb
+++ b/test/components/nav_bar/user_component_test.rb
@@ -97,12 +97,11 @@ class NavBar::UserComponentTest < ViewComponent::TestCase
   end
 
   test "shows red alert dot when new notifications exist" do
-    user = users(:business)
-    developer = developers(:one)
-    Message.create!(developer:, business: user.business, sender: developer, body: "Hello!")
-
+    user = users(:subscribed_business)
     render_inline NavBar::UserComponent.new(user, links: [])
-    assert_selector ".bg-red-400"
+    assert_selector "a[href='/notifications']" do
+      assert_selector ".bg-red-400"
+    end
   end
 
   test "does not show red alert dot when no new notifications exist" do

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+message:
+  type: NewMessageNotification
+  recipient: subscribed_business (User)
+  params:
+    _aj_symbol_keys:
+      - message
+      - conversation
+    message:
+      _aj_globalid: gid://railsdevs/Message/<%= ActiveRecord::FixtureSet.identify(:from_developer) %>
+    conversation:
+      _aj_globalid: gid://railsdevs/Conversation/<%= ActiveRecord::FixtureSet.identify(:one) %>

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class BusinessesTest < ActionDispatch::IntegrationTest
+  include NotificationsHelper
+
   test "can build a new business" do
     sign_in users(:empty)
     get new_business_path
@@ -38,12 +40,14 @@ class BusinessesTest < ActionDispatch::IntegrationTest
     sign_in user
 
     assert_difference ["Business.count", "Analytics::Event.count"], 1 do
-      post businesses_path, params: valid_business_params
+      assert_sends_notification NewBusinessNotification do
+        post businesses_path, params: valid_business_params
+      end
     end
+
     assert user.business.avatar.attached?
     assert_redirected_to Analytics::Event.last
     assert_equal Analytics::Event.last.url, developers_path
-    assert_equal Notification.last.type, NewBusinessNotification.name
   end
 
   test "successful business creation with a stored location" do

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -43,6 +43,7 @@ class BusinessesTest < ActionDispatch::IntegrationTest
     assert user.business.avatar.attached?
     assert_redirected_to Analytics::Event.last
     assert_equal Analytics::Event.last.url, developers_path
+    assert_equal Notification.last.type, NewBusinessNotification.name
   end
 
   test "successful business creation with a stored location" do

--- a/test/integration/cold_messages_test.rb
+++ b/test/integration/cold_messages_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class ColdMessagesTest < ActionDispatch::IntegrationTest
+  include NotificationsHelper
   include PayHelper
 
   setup do
@@ -61,7 +62,9 @@ class ColdMessagesTest < ActionDispatch::IntegrationTest
 
     assert_difference "Message.count", 1 do
       assert_difference "Conversation.count", 1 do
-        post developer_messages_path(@developer), params: message_params
+        assert_sends_notification NewConversationNotification do
+          post developer_messages_path(@developer), params: message_params
+        end
       end
     end
 

--- a/test/integration/conversations_test.rb
+++ b/test/integration/conversations_test.rb
@@ -49,17 +49,13 @@ class ConversationsTest < ActionDispatch::IntegrationTest
   end
 
   test "unread notifictions are marked as read" do
-    user = users(:prospect_developer)
-    developer = user.developer
-    business = businesses(:subscriber)
-    conversation = conversations(:one)
-    Message.create!(developer:, business:, body: "Hi!", sender: business, conversation:)
-    refute Notification.last.read?
+    sign_in users(:subscribed_business)
+    notification = notifications(:message)
+    refute notification.read?
 
-    sign_in user
-    get conversation_path(conversation)
+    get conversation_path(conversations(:one))
 
-    assert Notification.last.read?
+    assert notification.reload.read?
   end
 
   test "part-time plan subscribers can't message full-time seekers" do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -124,9 +124,13 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     sign_in users(:empty)
 
     assert_difference ["Developer.count", "Analytics::Event.count"], 1 do
-      post developers_path, params: valid_developer_params
+      assert_difference "Notification.count", 1 do
+        post developers_path, params: valid_developer_params
+      end
     end
+
     assert_redirected_to analytics_event_path(Analytics::Event.last)
+    assert_equal Notification.last.type, NewDeveloperProfileNotification.name
     assert_equal Analytics::Event.last.url, developer_path(Developer.last)
   end
 

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -125,14 +125,12 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     sign_in users(:empty)
 
     assert_difference ["Developer.count", "Analytics::Event.count"], 1 do
-      assert_difference "Notification.count", 1 do
+      assert_sends_notification NewDeveloperProfileNotification do
         post developers_path, params: valid_developer_params
       end
     end
 
     assert_redirected_to analytics_event_path(Analytics::Event.last)
-    assert_equal Notification.last.type, NewDeveloperProfileNotification.name
-    assert_equal Analytics::Event.last.url, developer_path(Developer.last)
   end
 
   test "create with nested attributes" do

--- a/test/integration/messages_test.rb
+++ b/test/integration/messages_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class MessagesTest < ActionDispatch::IntegrationTest
+  include NotificationsHelper
   include PayHelper
 
   setup do
@@ -28,7 +29,9 @@ class MessagesTest < ActionDispatch::IntegrationTest
 
     assert_difference "Message.count", 1 do
       assert_no_difference "Conversation.count" do
-        post conversation_messages_path(@conversation), params: message_params
+        assert_sends_notification NewMessageNotification do
+          post conversation_messages_path(@conversation), params: message_params
+        end
       end
     end
     assert_equal Message.last.sender, @developer

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -8,49 +8,36 @@ class NotificationsTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test "redirects to conversation if already sign in" do
-    user = users(:business)
-    developer = developers(:one)
-    sign_in user
-    message = create_message!(developer:, business: user.business)
-    notification = last_message_notification
+  test "redirects to notification if signed in" do
+    sign_in users(:subscribed_business)
+    notification = notifications(:message)
+    conversation = conversations(:one)
 
     get notification_path(notification)
-    assert_redirected_to conversation_path(message.conversation)
+    assert_redirected_to conversation_path(conversation)
   end
 
   test "you can view the new notifications page even if none exist" do
     sign_in users(:business)
-
     get notifications_path
     assert_select "h3", "No new notifications"
   end
 
   test "you can view your new notifications if you have new (unread) notifications" do
-    user = users(:business)
-    developer = developers(:one)
-    sign_in user
-    create_message!(developer:, business: user.business)
-
+    sign_in users(:subscribed_business)
     get notifications_path
     assert_select "h1", "New notifications"
   end
 
   test "viewing a notification marks it as read and redirects" do
-    user = users(:business)
-    developer = developers(:one)
-    sign_in user
-    message = create_message!(developer:, business: user.business)
-    notification = last_message_notification
+    sign_in users(:subscribed_business)
+    notification = notifications(:message)
+    conversation = conversations(:one)
 
     refute notification.reload.read?
     get notification_path(notification)
 
-    assert_redirected_to conversation_path(message.conversation)
+    assert_redirected_to conversation_path(conversation)
     assert notification.reload.read?
-  end
-
-  def create_message!(developer:, business:)
-    Message.create!(developer:, business:, sender: developer, body: "Hello!")
   end
 end

--- a/test/models/business_test.rb
+++ b/test/models/business_test.rb
@@ -2,15 +2,7 @@ require "test_helper"
 
 class BusinessTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
-
-  test "successful business creation sends a notification to the admin" do
-    assert_difference "Notification.count", 1 do
-      Business.create!(valid_business_attributes)
-    end
-
-    assert_equal Notification.last.type, NewBusinessNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
-  end
+  include BusinessesHelper
 
   test "conversations relationship doesn't include blocked ones" do
     business = businesses(:subscriber)
@@ -51,7 +43,7 @@ class BusinessTest < ActiveSupport::TestCase
   end
 
   test "anonymizes the filename of the avatar" do
-    business = Business.create!(valid_business_attributes)
+    business = Business.create!(business_attributes)
     assert_equal business.avatar.filename, "avatar.png"
   end
 
@@ -97,21 +89,5 @@ class BusinessTest < ActiveSupport::TestCase
     business = Business.new
 
     assert business.no_developer_notifications?
-  end
-
-  test "creating a business sends the welcome email" do
-    business = Business.create!(valid_business_attributes)
-    assert_enqueued_email_with BusinessMailer, :welcome_email, args: {business:}
-  end
-
-  def valid_business_attributes
-    {
-      user: users(:empty),
-      name: "Name",
-      company: "Company",
-      bio: "Bio",
-      avatar: active_storage_blobs(:basecamp),
-      developer_notifications: :no
-    }
   end
 end

--- a/test/models/concerns/businesses/notifications_test.rb
+++ b/test/models/concerns/businesses/notifications_test.rb
@@ -3,20 +3,18 @@ require "test_helper"
 class Businesses::NotificationsTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
   include BusinessesHelper
+  include NotificationsHelper
 
   test "sends a notification to the admins" do
     business = Business.new(business_attributes)
-    assert_difference "Notification.count", 1 do
+    assert_sends_notification NewBusinessNotification, to: users(:admin) do
       assert business.save_and_notify
     end
-
-    assert_equal Notification.last.type, NewBusinessNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
   end
 
   test "invalid records don't send notifications" do
     business = Business.new
-    assert_no_difference "Notification.count" do
+    refute_sends_notifications do
       refute business.save_and_notify
     end
   end

--- a/test/models/concerns/businesses/notifications_test.rb
+++ b/test/models/concerns/businesses/notifications_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Businesses::NotificationsTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+  include BusinessesHelper
+
+  test "sends a notification to the admins" do
+    business = Business.new(business_attributes)
+    assert_difference "Notification.count", 1 do
+      assert business.save_and_notify
+    end
+
+    assert_equal Notification.last.type, NewBusinessNotification.name
+    assert_equal Notification.last.recipient, users(:admin)
+  end
+
+  test "invalid records don't send notifications" do
+    business = Business.new
+    assert_no_difference "Notification.count" do
+      refute business.save_and_notify
+    end
+  end
+
+  test "sends the welcome email" do
+    business = Business.new(business_attributes)
+    assert business.save_and_notify
+    assert_enqueued_email_with BusinessMailer, :welcome_email, args: {business:}
+  end
+
+  test "invalid records don't send welcome emails" do
+    business = Business.new
+    refute business.save_and_notify
+    assert_no_enqueued_emails
+  end
+end

--- a/test/models/concerns/developers/notifications_test.rb
+++ b/test/models/concerns/developers/notifications_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Developers::NotificationsTest < ActiveSupport::TestCase
+  include DevelopersHelper
+  include ActionMailer::TestHelper
+
+  test "sends a notification to the admins" do
+    developer = Developer.new(developer_attributes)
+    assert_difference "Notification.count", 1 do
+      assert developer.save_and_notify
+    end
+
+    assert_equal Notification.last.type, NewDeveloperProfileNotification.name
+    assert_equal Notification.last.recipient, users(:admin)
+  end
+
+  test "invalid records don't send notifications" do
+    developer = Developer.new
+    assert_no_difference "Notification.count" do
+      refute developer.save_and_notify
+    end
+  end
+
+  test "sends a welcome email" do
+    developer = Developer.new(developer_attributes)
+    assert developer.save_and_notify
+    assert_enqueued_email_with DeveloperMailer, :welcome_email, args: {developer:}
+  end
+
+  test "invalid records don't send welcome emails" do
+    developer = Developer.new
+    refute developer.save_and_notify
+    assert_no_enqueued_emails
+  end
+
+  test "notifies the developer when they are invisibilized" do
+    assert_difference "Notification.count", 1 do
+      developers(:one).invisiblize_and_notify!
+    end
+
+    assert_equal Notification.last.type, InvisiblizeDeveloperNotification.name
+    assert_equal Notification.last.recipient, users(:developer)
+  end
+end

--- a/test/models/concerns/developers/notifications_test.rb
+++ b/test/models/concerns/developers/notifications_test.rb
@@ -1,22 +1,20 @@
 require "test_helper"
 
 class Developers::NotificationsTest < ActiveSupport::TestCase
-  include DevelopersHelper
   include ActionMailer::TestHelper
+  include DevelopersHelper
+  include NotificationsHelper
 
   test "sends a notification to the admins" do
     developer = Developer.new(developer_attributes)
-    assert_difference "Notification.count", 1 do
+    assert_sends_notification NewDeveloperProfileNotification, to: users(:admin) do
       assert developer.save_and_notify
     end
-
-    assert_equal Notification.last.type, NewDeveloperProfileNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
   end
 
   test "invalid records don't send notifications" do
     developer = Developer.new
-    assert_no_difference "Notification.count" do
+    refute_sends_notifications do
       refute developer.save_and_notify
     end
   end
@@ -34,11 +32,8 @@ class Developers::NotificationsTest < ActiveSupport::TestCase
   end
 
   test "notifies the developer when they are invisibilized" do
-    assert_difference "Notification.count", 1 do
+    assert_sends_notification InvisiblizeDeveloperNotification, to: users(:developer) do
       developers(:one).invisiblize_and_notify!
     end
-
-    assert_equal Notification.last.type, InvisiblizeDeveloperNotification.name
-    assert_equal Notification.last.recipient, users(:developer)
   end
 end

--- a/test/models/concerns/developers/notifications_test.rb
+++ b/test/models/concerns/developers/notifications_test.rb
@@ -38,13 +38,11 @@ class Developers::NotificationsTest < ActiveSupport::TestCase
       assert developer.update_and_notify(search_status: :open)
     end
 
-    assert_difference "Notification.count", 1 do
+    assert_sends_notification PotentialHireNotification, to: users(:admin) do
       assert developer.update_and_notify(search_status: :not_interested)
     end
-    assert_equal Notification.last.type, PotentialHireNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
 
-    assert_no_difference "Notification.count" do
+    refute_sends_notifications do
       assert developer.update_and_notify(search_status: :invisible)
     end
   end

--- a/test/models/concerns/messages/notifications_test.rb
+++ b/test/models/concerns/messages/notifications_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Messages::NotificationsTest < ActiveSupport::TestCase
+  include NotificationsHelper
+
+  test "sends a notification to the recipient" do
+    developer = developers(:one)
+    business = businesses(:one)
+
+    message = Message.new(developer:, business:, sender: business, body: "Hello!")
+    assert_sends_notification NewMessageNotification do
+      assert message.save_and_notify
+    end
+  end
+
+  test "sends a notifciation to admins if this started a new conversation" do
+    developer = developers(:one)
+    business = businesses(:one)
+
+    message = Message.new(developer:, business:, sender: business, body: "Hello!")
+
+    assert_sends_notification NewConversationNotification do
+      assert message.save_and_notify(cold_message: true)
+    end
+
+    refute_sends_notification NewConversationNotification do
+      assert message.save_and_notify(cold_message: false)
+    end
+  end
+
+  test "invalid records don't send notifications" do
+    message = Message.new
+    refute_sends_notifications do
+      refute message.save_and_notify
+    end
+  end
+end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -54,15 +54,6 @@ class ConversationTest < ActiveSupport::TestCase
     assert conversation.blocked?
   end
 
-  test "creating a conversation sends a notification to the admin" do
-    assert_difference "Notification.count", 1 do
-      Conversation.create!(developer: developers(:one), business: businesses(:one))
-    end
-
-    assert_equal Notification.last.type, NewConversationNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
-  end
-
   test "is eligible for the hiring fee when the developer has responded and it is 2+ weeks old" do
     conversation = conversations(:one)
     refute conversation.hiring_fee_eligible?

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class DeveloperTest < ActiveSupport::TestCase
   include DevelopersHelper
-  include ActionMailer::TestHelper
 
   setup do
     @developer = developers(:one)
@@ -80,15 +79,6 @@ class DeveloperTest < ActiveSupport::TestCase
       assert_includes developers, developers(:one)
       refute_includes developers, developers(:prospect)
     end
-  end
-
-  test "successful profile creation sends a notification to the admins" do
-    assert_difference "Notification.count", 1 do
-      Developer.create!(developer_attributes)
-    end
-
-    assert_equal Notification.last.type, NewDeveloperProfileNotification.name
-    assert_equal Notification.last.recipient, users(:admin)
   end
 
   test "should accept avatars of valid file formats" do
@@ -220,19 +210,5 @@ class DeveloperTest < ActiveSupport::TestCase
     refute_includes Developer.featured, developer
 
     travel_back
-  end
-
-  test "creating a developer sends the welcome email" do
-    developer = Developer.create!(developer_attributes)
-    assert_enqueued_email_with DeveloperMailer, :welcome_email, args: {developer:}
-  end
-
-  test "notifies the dev when they are invisibilized" do
-    assert_difference "Notification.count", 1 do
-      developers(:one).invisiblize!
-    end
-
-    assert_equal Notification.last.type, InvisiblizeDeveloperNotification.name
-    assert_equal Notification.last.recipient, users(:developer)
   end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class MessageTest < ActiveSupport::TestCase
-  include NotificationsHelper
-
   test "user is sender if they are the associated developer" do
     user = users(:prospect_developer)
     assert messages(:from_developer).sender?(user)
@@ -18,21 +16,6 @@ class MessageTest < ActiveSupport::TestCase
   test "user is not the sender if they are neither the associated developer nor business" do
     user = users(:empty)
     refute messages(:from_developer).sender?(user)
-  end
-
-  test "message creation sends a notification to the recipient" do
-    developer = developers(:one)
-    business = businesses(:one)
-
-    assert_difference "Notification.count", 2 do
-      Message.create!(developer:, business:, sender: business, body: "Hello!")
-    end
-
-    notification = last_message_notification
-    assert_equal notification.type, NewMessageNotification.name
-    assert_equal notification.recipient, developer.user
-    assert_equal notification.to_notification.message, Message.last
-    assert_equal notification.to_notification.conversation, Message.last.conversation
   end
 
   test "body_html is filled with rendered html version of body" do

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,21 +1,21 @@
 require "test_helper"
 
 class NotificationTest < ActiveSupport::TestCase
-  include NotificationsHelper
-
-  test "conversation resolves correctly" do
+  setup do
     developer = developers(:one)
     business = businesses(:one)
-    message = Message.create!(developer:, business:, sender: developer, body: "Hello!")
 
-    assert last_message_notification.to_notification.conversation == message.conversation
+    @message = Message.new(developer:, business:, sender: developer, body: "Hello!")
+    assert @message.save_and_notify
+
+    @notification = Notification.where(type: NewMessageNotification.name).last
   end
 
   test "message resolves correctly" do
-    developer = developers(:one)
-    business = businesses(:one)
-    message = Message.create!(developer:, business:, sender: developer, body: "Hello!")
+    assert @notification.to_notification.message == @message
+  end
 
-    assert last_message_notification.to_notification.message == message
+  test "conversation resolves correctly" do
+    assert @notification.to_notification.conversation == @message.conversation
   end
 end

--- a/test/support/helpers/businesses_helper.rb
+++ b/test/support/helpers/businesses_helper.rb
@@ -1,0 +1,12 @@
+module BusinessesHelper
+  def business_attributes
+    {
+      user: users(:empty),
+      name: "Name",
+      company: "Company",
+      bio: "Bio",
+      avatar: active_storage_blobs(:basecamp),
+      developer_notifications: :no
+    }
+  end
+end

--- a/test/support/helpers/notifications_helper.rb
+++ b/test/support/helpers/notifications_helper.rb
@@ -1,9 +1,23 @@
 module NotificationsHelper
-  extend ActiveSupport::Concern
+  def assert_sends_notification(notification_class, to: nil, &block)
+    assert_difference "Notification.where(type: #{notification_class}.name).count", 1 do
+      yield
 
-  included do
-    def last_message_notification
-      Notification.where(type: NewMessageNotification.to_s).last
+      if to.present?
+        assert_equal Notification.where(type: notification_class.name).last.recipient, to
+      end
+    end
+  end
+
+  def refute_sends_notification(notification_class, &block)
+    assert_no_difference "Notification.where(type: #{notification_class}.name).count" do
+      yield
+    end
+  end
+
+  def refute_sends_notifications
+    assert_no_difference "Notification.count" do
+      yield
     end
   end
 end


### PR DESCRIPTION
This PR moves callback-triggered email/notification sending to explicit methods.

### Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)