### PR TITLE
Add more info to `/admin/conversations` and show subscriptions to admins on business profiles

### DIFF
--- a/app/components/business_admin_component.html.erb
+++ b/app/components/business_admin_component.html.erb
@@ -1,0 +1,25 @@
+<div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-3xl mx-auto">
+  <div class="flex justify-between px-4 py-5 sm:px-6">
+    <h3 class="text-lg leading-6 font-medium text-gray-900">Business subscription</h3>
+    <% if stripe_customer? %>
+      <span class="ml-4 flex-shrink-0">
+        <%= link_to "Stripe account", stripe_url, class: "bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+      </span>
+    <% end %>
+  </div>
+
+  <div class="border-t border-gray-200 px-4 py-5 sm:p-0">
+    <% business.user.subscriptions.each do |subscription| %>
+      <dl class="sm:divide-y sm:divide-gray-200">
+        <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">Plan</dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><%= BusinessSubscription.from(subscription.processor_plan).name %></dd>
+        </div>
+        <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">Status</dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><%= subscription.status.humanize %></dd>
+        </div>
+      </dl>
+    <% end %>
+  </div>
+</div>

--- a/app/components/business_admin_component.html.erb
+++ b/app/components/business_admin_component.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-3xl mx-auto">
   <div class="flex justify-between px-4 py-5 sm:px-6">
-    <h3 class="text-lg leading-6 font-medium text-gray-900">Business subscription</h3>
+    <h3 class="text-lg leading-6 font-medium text-gray-900"><%= t("business_admin_component.title") %></h3>
     <% if stripe_customer? %>
       <span class="ml-4 flex-shrink-0">
         <%= link_to "Stripe account", stripe_url, class: "bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
@@ -12,11 +12,11 @@
     <% business.user.subscriptions.each do |subscription| %>
       <dl class="sm:divide-y sm:divide-gray-200">
         <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="text-sm font-medium text-gray-500">Plan</dt>
+          <dt class="text-sm font-medium text-gray-500"><%= t("business_admin_component.plan") %></dt>
           <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><%= BusinessSubscription.from(subscription.processor_plan).name %></dd>
         </div>
         <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-          <dt class="text-sm font-medium text-gray-500">Status</dt>
+          <dt class="text-sm font-medium text-gray-500"><%= t("business_admin_component.status") %></dt>
           <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2"><%= subscription.status.humanize %></dd>
         </div>
       </dl>

--- a/app/components/business_admin_component.rb
+++ b/app/components/business_admin_component.rb
@@ -1,0 +1,34 @@
+class BusinessAdminComponent < ApplicationComponent
+  attr_reader :business, :user
+
+  def initialize(business, user:)
+    @business = business
+    @user = user
+  end
+
+  def render?
+    user&.admin?
+  end
+
+  def stripe_customer?
+    customer&.stripe?
+  end
+
+  def stripe_url
+    if live?
+      "https://dashboard.stripe.com/customers/#{customer.processor_id}"
+    else
+      "https://dashboard.stripe.com/test/customers/#{customer.processor_id}"
+    end
+  end
+
+  private
+
+  def customer
+    business.user.payment_processor
+  end
+
+  def live?
+    customer.processor_id.starts_with?("cus_")
+  end
+end

--- a/app/controllers/admin/business_conversations_controller.rb
+++ b/app/controllers/admin/business_conversations_controller.rb
@@ -2,18 +2,17 @@ module Admin
   class BusinessConversationsController < ConversationsController
     def index
       super
-      @title = "#{business.company}'s conversations"
       render "admin/conversations/index"
     end
 
     private
 
-    def business
-      @business ||= Business.find(params[:business_id])
+    def entity
+      @entity ||= Business.find(params[:business_id])
     end
 
-    def all_conversations
-      @all_conversations ||= business.conversations
+    def title
+      entity.company
     end
   end
 end

--- a/app/controllers/admin/conversations_controller.rb
+++ b/app/controllers/admin/conversations_controller.rb
@@ -1,27 +1,17 @@
 module Admin
   class ConversationsController < ApplicationController
-    include Pagy::Backend
-
     def index
-      @title = "Conversations"
-      @stats = Stats::Conversation.new(conversations)
-      @pagy, @conversations = pagy(conversations)
-      @replied_to_conversation_ids = replied_to_conversation_ids
+      @context = ConversationsContext.new(entity, title:, options: params)
     end
 
     private
 
-    def all_conversations
-      Conversation.all
+    def entity
+      nil
     end
 
-    def conversations
-      @conversations ||= all_conversations.includes(:business, :developer).order(created_at: :desc)
-    end
-
-    def replied_to_conversation_ids
-      Message.where(sender_type: "Developer", conversation: conversations)
-        .distinct.pluck(:conversation_id)
+    def title
+      t("admin.conversations.index.title")
     end
   end
 end

--- a/app/controllers/admin/developer_conversations_controller.rb
+++ b/app/controllers/admin/developer_conversations_controller.rb
@@ -2,18 +2,17 @@ module Admin
   class DeveloperConversationsController < ConversationsController
     def index
       super
-      @title = "#{developer.name}'s conversations"
       render "admin/conversations/index"
     end
 
     private
 
-    def developer
-      @business ||= Developer.find(params[:developer_id])
+    def entity
+      @entity ||= Developer.find(params[:developer_id])
     end
 
-    def all_conversations
-      @all_conversations ||= developer.conversations
+    def title
+      entity.name
     end
   end
 end

--- a/app/models/admin/conversations_context.rb
+++ b/app/models/admin/conversations_context.rb
@@ -1,0 +1,19 @@
+module Admin
+  class ConversationsContext
+    attr_reader :entity, :title, :options
+
+    def initialize(entity, title:, options:)
+      @entity = entity
+      @title = title
+      @options = options
+    end
+
+    def query
+      @query ||= ConversationQuery.new(entity, options)
+    end
+
+    def stats
+      @status ||= Stats::Conversation.new(query.all_records)
+    end
+  end
+end

--- a/app/models/admin/conversations_context.rb
+++ b/app/models/admin/conversations_context.rb
@@ -13,7 +13,7 @@ module Admin
     end
 
     def stats
-      @status ||= Stats::Conversation.new(query.all_records)
+      @stats ||= Stats::Conversation.new(query.all_records)
     end
   end
 end

--- a/app/models/business_subscription.rb
+++ b/app/models/business_subscription.rb
@@ -19,7 +19,7 @@ module BusinessSubscription
     elsif Free.new.plan == price
       Free.new
     else
-      raise UnknownPrice.new
+      raise UnknownPrice.new("Unknown price: #{price}")
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,6 +18,7 @@ class Message < ApplicationRecord
   validates :hiring_fee_agreement, acceptance: true
 
   scope :from_developer, -> { where(sender_type: Developer.name) }
+  scope :potential_email, -> { where("body LIKE ?", "%@%") }
 
   def sender?(user)
     [user.developer, user.business].include?(sender)

--- a/app/queries/conversation_query.rb
+++ b/app/queries/conversation_query.rb
@@ -1,0 +1,51 @@
+class ConversationQuery
+  include Pagy::Backend
+
+  attr_reader :entity, :options
+
+  alias_method :build_pagy, :pagy
+
+  def initialize(entity = nil, options = {})
+    @entity = entity
+    @options = options
+  end
+
+  def pagy
+    @pagy ||= query_and_paginate.first
+  end
+
+  def records
+    @records ||= query_and_paginate.last
+  end
+
+  def all_records
+    @all_records ||= entity.present? ? entity.conversations : Conversation.all
+  end
+
+  def replied_to_conversation_ids
+    @replied_to_conversation_ids ||=
+      Message.where(sender_type: "Developer", conversation: records)
+        .distinct.pluck(:conversation_id)
+  end
+
+  def potential_email_conversation_ids
+    @potential_email_conversation_ids ||=
+      Message.where(conversation: records)
+        .potential_email
+        .distinct.pluck(:conversation_id)
+  end
+
+  private
+
+  def query_and_paginate
+    records = all_records
+      .includes(:business, :developer)
+      .order(created_at: :desc)
+    @pagy, @records = build_pagy(records)
+  end
+
+  # Needed for #pagy (aliased to #build_pagy) helper.
+  def params
+    options
+  end
+end

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -21,11 +21,11 @@ class DeveloperQuery
   end
 
   def pagy
-    @pagy ||= initialize_pagy_and_developers.first
+    @pagy ||= query_and_paginate.first
   end
 
   def records
-    @records ||= initialize_pagy_and_developers.last
+    @records ||= query_and_paginate.last
   end
 
   def featured_records
@@ -62,7 +62,7 @@ class DeveloperQuery
 
   private
 
-  def initialize_pagy_and_developers
+  def query_and_paginate
     @_records = Developer.includes(:role_type).with_attached_avatar.visible
     sort_records
     utc_offset_filter_records

--- a/app/views/admin/conversations/_conversations.html.erb
+++ b/app/views/admin/conversations/_conversations.html.erb
@@ -9,7 +9,7 @@
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".developer") %></th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".started") %></th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".replied") %>?</th>
-              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Email?</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".email") %></th>
               <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
                 <span class="sr-only"><%= t(".view") %></span>
               </th>
@@ -41,10 +41,10 @@
 
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                   <% if query.potential_email_conversation_ids.include?(conversation.id) %>
-                    <span class="sr-only">Potential email</span>
+                    <span class="sr-only"><%= t(".potential_email") %></span>
                     <%= inline_svg_tag "icons/outline/check.svg", class: "w-4 h-4 text-gray-800" %>
                   <% else %>
-                    <span class="sr-only">No</span>
+                    <span class="sr-only"><%= t(".no_potential_email") %></span>
                   <% end %>
                 </td>
 

--- a/app/views/admin/conversations/_conversations.html.erb
+++ b/app/views/admin/conversations/_conversations.html.erb
@@ -9,13 +9,14 @@
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".developer") %></th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".started") %></th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"><%= t(".replied") %>?</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Email?</th>
               <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
                 <span class="sr-only"><%= t(".view") %></span>
               </th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
-            <% conversations.each do |conversation| %>
+            <% query.records.each do |conversation| %>
               <tr>
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                   <%= link_to "#{conversation.business.company} (#{conversation.business.contact_name})", admin_business_conversations_path(conversation.business), class: "hover:underline" %>
@@ -30,11 +31,20 @@
                 </td>
 
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                  <% if replied_to_conversation_ids.include?(conversation.id) %>
+                  <% if query.replied_to_conversation_ids.include?(conversation.id) %>
                     <span class="sr-only"><%= t(".replied") %></span>
                     <%= inline_svg_tag "icons/outline/check.svg", class: "w-4 h-4 text-gray-800" %>
                   <% else %>
                     <span class="sr-only"><%= t(".no_response") %></span>
+                  <% end %>
+                </td>
+
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  <% if query.potential_email_conversation_ids.include?(conversation.id) %>
+                    <span class="sr-only">Potential email</span>
+                    <%= inline_svg_tag "icons/outline/check.svg", class: "w-4 h-4 text-gray-800" %>
+                  <% else %>
+                    <span class="sr-only">No</span>
                   <% end %>
                 </td>
 

--- a/app/views/admin/conversations/index.html.erb
+++ b/app/views/admin/conversations/index.html.erb
@@ -1,16 +1,24 @@
 <div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <h1 class="mt-6 text-center text-3xl font-extrabold"><%= @title %></h1>
+  <div class="flex items-center justify-center">
+    <h1 class="mt-6 text-center text-3xl font-extrabold">
+      <% if @context.entity.present? %>
+        <%= t ".title_html", href: link_to(@context.title, polymorphic_path(@context.entity), class: "hover:underline") %>
+      <% else %>
+        <%= @context.title %>
+      <% end %>
+    </h1>
+  </div>
 
   <div class="max-w-sm sm:max-w-2xl mx-auto mt-8 w-full">
     <div class="px-4 sm:px-6 lg:px-8">
-      <%= render "stats", stats: @stats %>
+      <%= render "stats", stats: @context.stats %>
     </div>
   </div>
 
-  <div class="max-w-4xl mx-auto mt-8 w-full overflow-scroll">
+  <div class="max-w-5xl mx-auto mt-8 w-full overflow-scroll">
     <div class="px-4 sm:px-6 lg:px-8">
-      <%= render "conversations", conversations: @conversations, replied_to_conversation_ids: @replied_to_conversation_ids %>
-      <%== pagy_nav @pagy %>
+      <%= render "conversations", query: @context.query %>
+      <%== pagy_nav @context.query.pagy %>
     </div>
   </div>
 </div>

--- a/app/views/businesses/show.html.erb
+++ b/app/views/businesses/show.html.erb
@@ -1,7 +1,7 @@
 <%= render BusinessOpenGraphTagsComponent.new(business: @business) %>
 
-<div class="md:mt-16 pb-8 mb-16">
-  <div class="bg-white md:shadow md:rounded max-w-3xl mx-auto px-4 py-8 sm:px-6">
+<div class="md:mt-16 pb-8">
+  <div class="bg-white shadow overflow-hidden sm:rounded-lg max-w-3xl mx-auto px-4 py-8 sm:px-6">
     <div class="px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-5">
       <div class="flex items-center space-x-5">
         <div class="hidden sm:block flex-shrink-0">
@@ -17,7 +17,7 @@
               <%= inline_svg_tag "icons/solid/external_link.svg", class: "h-6 w-6 flex-shrink-0 text-gray-500 group-hover:text-gray-700 ml-1" %>
             <% end %>
           <% else %>
-              <h1 class="text-3xl font-bold text-gray-900"><%= @business.company %></h1>
+            <h1 class="text-3xl font-bold text-gray-900"><%= @business.company %></h1>
           <% end %>
           <p class="text-gray-500 mt-1"><%= [@business.contact_name, @business.contact_role].map(&:presence).compact.join(", ") %></p>
         </div>
@@ -40,3 +40,5 @@
     </div>
   </div>
 </div>
+
+<%= render BusinessAdminComponent.new(@business, user: current_user) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
         index:
           title: Blocked conversations
       conversations:
-        Email: email
+        email: email
         business: Business
         developer: Developer
         no_potential_email: No potential email
@@ -110,7 +110,7 @@ en:
       message: Are you sure you want to flag this conversation and block the sender? This will hide the conversation and they won't be able to contact you again.
       title: Block sender
   business_admin_component:
-    Status: Status
+    status: Status
     plan: Plan
     title: Business subscription
   business_primary_action_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,9 +69,12 @@ en:
         index:
           title: Blocked conversations
       conversations:
+        Email: email
         business: Business
         developer: Developer
+        no_potential_email: No potential email
         no_response: No response
+        potential_email: Potential email
         replied: Replied
         started: Started
         view: View

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,9 +69,9 @@ en:
         index:
           title: Blocked conversations
       conversations:
-        email: email
         business: Business
         developer: Developer
+        email: email
         no_potential_email: No potential email
         no_response: No response
         potential_email: Potential email
@@ -110,8 +110,8 @@ en:
       message: Are you sure you want to flag this conversation and block the sender? This will hide the conversation and they won't be able to contact you again.
       title: Block sender
   business_admin_component:
-    status: Status
     plan: Plan
+    status: Status
     title: Business subscription
   business_primary_action_component:
     edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,9 @@ en:
         replied: Replied
         started: Started
         view: View
+      index:
+        title: Conversations
+        title_html: "%{href}'s conversations"
       stats:
         reply_rate: Reply rate
         started: Started

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,10 @@ en:
       cancel: Cancel
       message: Are you sure you want to flag this conversation and block the sender? This will hide the conversation and they won't be able to contact you again.
       title: Block sender
+  business_admin_component:
+    Status: Status
+    plan: Plan
+    title: Business subscription
   business_primary_action_component:
     edit: Edit
   businesses:

--- a/test/components/business_admin_component_test.rb
+++ b/test/components/business_admin_component_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class BusinessAdminComponentTest < ViewComponent::TestCase
+  test "renders for admins" do
+    business = businesses(:subscriber)
+
+    user = nil
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_no_selector "*"
+
+    user = users(:developer)
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_no_selector "*"
+
+    user = users(:admin)
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_selector "dl"
+  end
+
+  test "renders a Stripe link for Stripe customers" do
+    business = businesses(:subscriber)
+    user = users(:admin)
+
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_selector "a"
+
+    business.user.payment_processor.update!(processor: :fake)
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_no_selector "a"
+  end
+
+  test "links to production or test Stripe dashboard" do
+    business = businesses(:subscriber)
+    user = users(:admin)
+
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_selector "a[href*='stripe.com/customers']"
+
+    business.user.payment_processor.update!(processor_id: "not_stripe_1234")
+    render_inline BusinessAdminComponent.new(business, user:)
+    assert_selector "a[href*='stripe.com/test/customers']"
+  end
+end

--- a/test/integration/admin/conversations_test.rb
+++ b/test/integration/admin/conversations_test.rb
@@ -12,9 +12,34 @@ class Admin::ConversationsTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test "calculates stats" do
+  test "lists conversations" do
     sign_in users(:admin)
     get admin_conversations_path
-    assert_select "p", text: "100%"
+
+    assert_select "h1", I18n.t("admin.conversations.index.title")
+    assert_select "td", text: "#{businesses(:subscriber).company} (#{businesses(:subscriber).name})"
+    assert_select "td", text: developers(:prospect).name
+  end
+
+  test "lists developer conversations" do
+    sign_in users(:admin)
+    developer = developers(:prospect)
+
+    get admin_developer_conversations_path(developer)
+
+    assert_select "h1", text: "#{developer.name}'s conversations" do
+      assert_select "a[href=?]", developer_path(developer), text: developer.name
+    end
+  end
+
+  test "lists business conversations" do
+    sign_in users(:admin)
+    business = businesses(:subscriber)
+
+    get admin_business_conversations_path(business)
+
+    assert_select "h1", text: "#{business.company}'s conversations" do
+      assert_select "a[href=?]", business_path(business), text: business.company
+    end
   end
 end

--- a/test/queries/conversation_query_test.rb
+++ b/test/queries/conversation_query_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ConversationQueryTest < ActiveSupport::TestCase
+  include BusinessesHelper
+  include DevelopersHelper
+
+  test "all conversations if entity isn't provided" do
+    conversation = create_conversation
+    query = ConversationQuery.new(nil)
+    assert_includes query.records, conversation
+  end
+
+  test "conversations involving the entity, if provided" do
+    developer = create_developer
+    developer_conversation = create_conversation(developer:)
+    other_conversation = create_conversation
+
+    query = ConversationQuery.new(developer)
+
+    assert_includes query.records, developer_conversation
+    refute_includes query.records, other_conversation
+  end
+
+  test "conversations where the developer replied" do
+    developer = create_developer
+    business = create_business
+
+    replied_to_conversation = create_conversation(developer:)
+    replied_to_conversation.messages.create!(sender: developer, body: "Hi, business!")
+    left_read_conversation = create_conversation(business:)
+    left_read_conversation.messages.create!(sender: business, body: "Hi, developer!")
+
+    query = ConversationQuery.new(nil)
+
+    assert_includes query.replied_to_conversation_ids, replied_to_conversation.id
+    refute_includes query.replied_to_conversation_ids, left_read_conversation.id
+  end
+
+  test "conversations where a message contains an email address" do
+    developer = create_developer
+
+    conversation_with_email = create_conversation(developer:)
+    conversation_with_email.messages.create!(sender: developer, body: "me@example.com")
+    other_conversation = create_conversation
+    other_conversation.messages.create!(sender: developer, body: "Hi!")
+
+    query = ConversationQuery.new(nil)
+
+    assert_includes query.potential_email_conversation_ids, conversation_with_email.id
+    refute_includes query.potential_email_conversation_ids, other_conversation.id
+  end
+
+  def create_conversation(developer: nil, business: nil)
+    developer ||= create_developer
+    business ||= create_business
+    Conversation.create(developer:, business:)
+  end
+end

--- a/test/support/helpers/businesses_helper.rb
+++ b/test/support/helpers/businesses_helper.rb
@@ -9,4 +9,8 @@ module BusinessesHelper
       developer_notifications: :no
     }
   end
+
+  def create_business(options = {})
+    Business.create!(business_attributes.merge(options))
+  end
 end


### PR DESCRIPTION
This PR does two things (and arguably should be split into two PRs):

1. Adds a new column to `/admin/conversations` to check for the `@` symbol in any message. This is an indication that the conversation moved off of railsdevs and a hire was potentially made.
2. Adds an admin card to the business profile page showing which subscription(s) a business has. Also links to their Stripe customer page.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)