### PR TITLE
Add country filter logic to backend

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -47,12 +47,12 @@ class Developer < ApplicationRecord
     }.reduce(:or).joins(:role_level)
   end
 
-  scope :filter_by_utc_offset, ->(utc_offset) do
-    joins(:location).where(locations: {utc_offset:})
+  scope :filter_by_utc_offsets, ->(utc_offsets) do
+    joins(:location).where(locations: {utc_offset: utc_offsets})
   end
 
-  scope :filter_by_country, ->(country) do
-    joins(:location).where(locations: {country:})
+  scope :filter_by_countries, ->(countries) do
+    joins(:location).where(locations: {country: countries})
   end
 
   scope :available, -> { where(available_on: ..Time.current.to_date) }

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -51,6 +51,10 @@ class Developer < ApplicationRecord
     joins(:location).where(locations: {utc_offset:})
   end
 
+  scope :filter_by_country, ->(country) do
+    joins(:location).where(locations: {country:})
+  end
+
   scope :available, -> { where(available_on: ..Time.current.to_date) }
   scope :available_first, -> { where.not(available_on: nil).order(:available_on) }
   scope :newest_first, -> { order(created_at: :desc) }

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -42,7 +42,7 @@ class DeveloperQuery
   end
 
   def countries
-    @countries.to_a
+    @countries.to_a.reject(&:blank?)
   end
 
   def utc_offsets

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -100,12 +100,12 @@ class DeveloperQuery
   end
 
   def country_filter_records
-    @_records.merge!(Developer.filter_by_country(countries)) if countries.any?
+    @_records.merge!(Developer.filter_by_countries(countries)) if countries.any?
   end
 
   def utc_offset_filter_records
     if utc_offsets.any?
-      @_records.merge!(Developer.filter_by_utc_offset(utc_offsets))
+      @_records.merge!(Developer.filter_by_utc_offsets(utc_offsets))
     end
   end
 

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -9,6 +9,7 @@ class DeveloperQuery
     @options = options
     @items_per_page = options.delete(:items_per_page)
     @sort = options.delete(:sort)
+    @countries = options.delete(:countries)
     @utc_offsets = options.delete(:utc_offsets)
     @role_types = options.delete(:role_types)
     @role_levels = options.delete(:role_levels)
@@ -40,6 +41,10 @@ class DeveloperQuery
     @sort.to_s.downcase.to_sym == :availability ? :availability : :newest
   end
 
+  def countries
+    @countries.to_a
+  end
+
   def utc_offsets
     @utc_offsets.to_a.reject(&:blank?).map(&:to_f)
   end
@@ -65,6 +70,7 @@ class DeveloperQuery
   def query_and_paginate
     @_records = Developer.includes(:role_type).with_attached_avatar.visible
     sort_records
+    country_filter_records
     utc_offset_filter_records
     role_type_filter_records
     role_level_filter_records
@@ -91,6 +97,10 @@ class DeveloperQuery
     else
       @_records.merge!(Developer.newest_first)
     end
+  end
+
+  def country_filter_records
+    @_records.merge!(Developer.filter_by_country(countries)) if countries.any?
   end
 
   def utc_offset_filter_records

--- a/db/seeds/locations.yml
+++ b/db/seeds/locations.yml
@@ -1,7 +1,7 @@
 new_york:
   city: New York
   state: New York
-  country: Unitd States
+  country: United States
   country_code: us
   latitude: 40.7127281
   longitude: -74.0060152

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -52,7 +52,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
   end
 
   test "developers can be filtered by time zone" do
-    create_developer(hero: "Pacific", utc_offset: PACIFIC_UTC_OFFSET)
+    create_developer(hero: "Pacific", location_attributes: { utc_offset: PACIFIC_UTC_OFFSET })
 
     get developers_path(utc_offsets: [PACIFIC_UTC_OFFSET])
 

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -52,7 +52,7 @@ class DevelopersTest < ActionDispatch::IntegrationTest
   end
 
   test "developers can be filtered by time zone" do
-    create_developer(hero: "Pacific", location_attributes: { utc_offset: PACIFIC_UTC_OFFSET })
+    create_developer(hero: "Pacific", location_attributes: {utc_offset: PACIFIC_UTC_OFFSET})
 
     get developers_path(utc_offsets: [PACIFIC_UTC_OFFSET])
 

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -82,6 +82,16 @@ class DeveloperQueryTest < ActiveSupport::TestCase
     assert records.find_index(newest) < records.find_index(oldest)
   end
 
+  test "filtering by countries" do
+    united_states = create_developer
+    singapore = create_developer(location_attributes: {country: "Singapore"})
+
+    records = DeveloperQuery.new(countries: ["Singapore"]).records
+
+    assert_includes records, singapore
+    refute_includes records, united_states
+  end
+
   test "filtering by time zones" do
     eastern = create_developer(location_attributes: {utc_offset: EASTERN_UTC_OFFSET})
     pacific = create_developer(location_attributes: {utc_offset: PACIFIC_UTC_OFFSET})

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -83,8 +83,8 @@ class DeveloperQueryTest < ActiveSupport::TestCase
   end
 
   test "filtering by time zones" do
-    eastern = create_developer(utc_offset: EASTERN_UTC_OFFSET)
-    pacific = create_developer(utc_offset: PACIFIC_UTC_OFFSET)
+    eastern = create_developer(location_attributes: {utc_offset: EASTERN_UTC_OFFSET})
+    pacific = create_developer(location_attributes: {utc_offset: PACIFIC_UTC_OFFSET})
 
     records = DeveloperQuery.new(utc_offsets: [PACIFIC_UTC_OFFSET]).records
 

--- a/test/support/helpers/developers_helper.rb
+++ b/test/support/helpers/developers_helper.rb
@@ -21,8 +21,8 @@ module DevelopersHelper
         options[:search_status] = :open
       end
 
-      if (utc_offset = options.delete(:utc_offset))
-        options[:location_attributes] = location_attributes(utc_offset)
+      if (location_attributes = options.delete(:location_attributes))
+        options[:location_attributes] = default_location_attributes.merge(location_attributes)
       end
 
       Developer.create!(developer_attributes.merge(options))
@@ -30,13 +30,12 @@ module DevelopersHelper
 
     private
 
-    def location_attributes(utc_offset)
+    def default_location_attributes
       {
         latitude: 1,
         longitude: 2,
         country: "United States",
-        time_zone: "Fake Time Zone",
-        utc_offset:
+        time_zone: "Fake Time Zone"
       }
     end
   end

--- a/test/support/helpers/developers_helper.rb
+++ b/test/support/helpers/developers_helper.rb
@@ -35,7 +35,8 @@ module DevelopersHelper
         latitude: 1,
         longitude: 2,
         country: "United States",
-        time_zone: "Fake Time Zone"
+        time_zone: "Fake Time Zone",
+        utc_offset: -8 * 60 * 60
       }
     end
   end


### PR DESCRIPTION
Partially addresses https://github.com/joemasilotti/railsdevs.com/issues/297, adding the filtering logic for countries. This doesn't touch the frontend at all.

For now my assumption is we're going to build the list of countries from the Location models (something like `Location.select(:country).distinct.pluck(:country)`. Do you intend to rework the country handling at some point e.g. have a predefined list of countries for a dropdown, and should I take that into consideration if so?

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
