### PR TITLE
Fix race condition in test

### DIFF
--- a/test/system/messaging_test.rb
+++ b/test/system/messaging_test.rb
@@ -8,6 +8,8 @@ class MessagingTest < ApplicationSystemTestCase
     fill_in "Add your message", with: "Hello!"
     click_button "Send"
 
-    assert_text "Hello!"
+    within "#messages" do
+      assert_text "Hello!"
+    end
   end
 end


### PR DESCRIPTION
Ensures message text is inside a sent message and not the input field.

The idea is that the test might have been incorrectly passing because the assertion fired right away - before the message even "sent".

Fixes #437

<!-- Description of pull request linking to any relevant issues. -->

### Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
