### PR TITLE
Specify `postgresql@13` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew bundle install --no-upgrade
 * Ruby 3.1.0
 * [libpq](https://www.postgresql.org/docs/9.5/libpq.html) - `brew install libpq`
     * `libpg` is needed to use the native `pg` gem without Rosetta on M1 macs
-* [postgresql](https://www.postgresql.org) - `brew install postgresql`
+* [postgresql](https://www.postgresql.org) - `brew install postgresql@13`
 * [node](https://nodejs.org/en/) - `brew install node`
 * [Yarn](https://yarnpkg.com) - `brew install yarn`
 * [Redis](https://redis.io) - `brew install redis`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ brew bundle install --no-upgrade
 * Ruby 3.1.0
 * [libpq](https://www.postgresql.org/docs/9.5/libpq.html) - `brew install libpq`
     * `libpg` is needed to use the native `pg` gem without Rosetta on M1 macs
-* [postgresql](https://www.postgresql.org) - `brew install postgresql@13`
+* [postgresql](https://www.postgresql.org) - `brew install postgresql` [Note: PostgreSQL 13+ is required]
 * [node](https://nodejs.org/en/) - `brew install node`
 * [Yarn](https://yarnpkg.com) - `brew install yarn`
 * [Redis](https://redis.io) - `brew install redis`


### PR DESCRIPTION
NOTE: **_No code is touched in this PR_** 😉 

Small README modification to ensure that developers are using at **least** `PostgreSQL@13` if installed via `Homebrew`.
REF this issue: [bin/setup failed on fresh install #426](https://github.com/joemasilotti/railsdevs.com/issues/426)

### Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)
