### PR TITLE
Isolate conversation checking from Messaging::Message

### DIFF
--- a/app/controllers/cold_messages_controller.rb
+++ b/app/controllers/cold_messages_controller.rb
@@ -2,6 +2,11 @@ class ColdMessagesController < ApplicationController
   before_action :authenticate_user!
 
   def new
+    conversation = Messaging::FindConversation.find(current_user, developer_id:)
+    if conversation
+      redirect_to conversation and return
+    end
+
     result = Messaging::Message.new(current_user, developer_id:).build_message
     if result.success?
       @cold_message = result.cold_message
@@ -33,8 +38,6 @@ class ColdMessagesController < ApplicationController
 
     if result.missing_business?
       redirect_to new_business_path, notice: result.message
-    elsif result.existing_conversation?
-      redirect_to result.conversation
     elsif result.invalid_subscription?
       redirect_to pricing_path
     end

--- a/app/services/messaging/message.rb
+++ b/app/services/messaging/message.rb
@@ -82,9 +82,6 @@ module Messaging
         false
       end
 
-      def existing_conversation?
-        false
-      end
 
       def invalid_subscription?
         false


### PR DESCRIPTION
(Apologies for the shortness of the PR, I thought I had more battery power than I do!)

I think some of the complexity from these service objects stems from an "expansion" of responsibilities. For example, your `Messaging::Message` service object:

1. Checks if the business is present
2. Checks if the conversation is present
3. Checks if the subscription is active
4. Creates messages
5. Sends notifications

I like #4 and #5 being the responsibility of this service class. It doesn't make sense to separate those out to their own individual classes -- no point sending notifications _separately_ to creating a message (at this point in time).

I think those first three checks though could be done outside of this class and so that the class then handles all the "happy path" type stuff. 

1. YES there is a business
2. YES there is a conversation 
3. YES the subscription is active

The check for a business and active subscription could be done as a _separate_ "service" that I sub-optimally would call "CanThisUserSendAMesssage". Think of them as "pre-flight" checks to actually sending a message. 

I think that approach would mean that your `Messaging::Message` service would be able to cut down its responsibilities, and then from there it should be easier to reason about.

---

I mentioned the `Result` type of `dry-monads` in our Twitter thread, but I think you might also like the "Do notation" as well which would allow you to write code like:

```
def send_message(*args)
  message = yield create_message(options, conversation:)
  yield send_notifications(message)

  Success(message)
end
```

And that would untie the `create_message` and `send_notifications` methods. If the `create_message` method returns a `Failure` result, then the `send_notifications` method won't be called. 

By splitting those methods up, if you wanted to test them in isolation (create a message without sending a notification or vice versa), then you would be able to do that easily.