### PR TITLE
Remove HTML from developer bios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### May
 
+* May 26 - Strip HTML tags from developer bios - #446
 * May 21 - Accessibility updates - #436 and #440 @metamoni
 * May 9 - Send daily/weekly emails via broadcast stream - #421
 * May 8 - Send automated emails from `@railsdevs.com` -#414

--- a/app/components/developer_card_component.html.erb
+++ b/app/components/developer_card_component.html.erb
@@ -22,7 +22,7 @@
       <% end %>
 
       <div class="mt-2 text-sm sm:text-base text-gray-700 space-y-4">
-        <p class="line-clamp-3 break-words"><%= bio %></p>
+        <p class="line-clamp-3 break-words"><%= strip_tags bio %></p>
       </div>
     </div>
   <% end %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -36,7 +36,7 @@
               <div class="py-3 lg:pt-6 lg:pb-0">
                 <h2 class="sr-only"><%= t(".description") %></h2>
                 <div class="prose max-w-prose">
-                  <%= simple_format @developer.bio %>
+                  <%= simple_format(strip_tags(@developer.bio)) %>
                 </div>
               </div>
             </div>

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -158,6 +158,17 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_description_contains developer.bio
   end
 
+  test "developer bios are stripped of HTML tags and new lines are converted to <p> tags" do
+    developer = developers(:one)
+    developer.update!(bio: "Line one\n\nLine two\n\n<h1>Header</h1>")
+
+    get developer_path(developer)
+
+    assert_select "p", text: "Line one"
+    assert_select "p", text: "Line two"
+    assert_select "p", text: "Header"
+  end
+
   test "successful edit to profile" do
     sign_in users(:developer)
     developer = developers(:one)


### PR DESCRIPTION
Fixes #444 by stripping HTML tags when rendering developer bios.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)