### PR TITLE
Move static markdown rendering to view layer

### DIFF
--- a/app/components/markdown_component.html.erb
+++ b/app/components/markdown_component.html.erb
@@ -1,0 +1,1 @@
+<%== rendered_markdown %>

--- a/app/components/markdown_component.rb
+++ b/app/components/markdown_component.rb
@@ -23,6 +23,6 @@ class MarkdownComponent < ApplicationComponent
   end
 
   def rendered_markdown
-    MarkdownRenderer.new(path, localize: localize).render
+    MarkdownRenderer.new(path, localize:).render
   end
 end

--- a/app/components/markdown_component.rb
+++ b/app/components/markdown_component.rb
@@ -1,0 +1,28 @@
+class MarkdownComponent < ApplicationComponent
+  private attr_reader :path, :localize
+
+  def initialize(path, localize: true)
+    @path = path
+    @localize = localize
+  end
+
+  def self.messaging_tips
+    new("cold_messages/tips")
+  end
+
+  def self.about_hero
+    new("about/hero")
+  end
+
+  def self.about_body
+    new("about/body")
+  end
+
+  def self.code_of_coduct
+    new("CODE_OF_CONDUCT.md", localize: false)
+  end
+
+  def rendered_markdown
+    MarkdownRenderer.new(path, localize: localize).render
+  end
+end

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,6 +1,4 @@
 class AboutController < ApplicationController
   def show
-    @hero = MarkdownRenderer.new("about/hero").render
-    @body = MarkdownRenderer.new("about/body").render
   end
 end

--- a/app/controllers/cold_messages_controller.rb
+++ b/app/controllers/cold_messages_controller.rb
@@ -24,8 +24,7 @@ class ColdMessagesController < ApplicationController
   def cold_message(message)
     ColdMessage.new(
       message:,
-      show_hiring_fee_terms: current_user.active_full_time_business_subscription?,
-      tips: MarkdownRenderer.new("cold_messages/tips").render
+      show_hiring_fee_terms: current_user.active_full_time_business_subscription?
     )
   end
 

--- a/app/controllers/conducts_controller.rb
+++ b/app/controllers/conducts_controller.rb
@@ -1,15 +1,4 @@
 class ConductsController < ApplicationController
   def show
-    @body = renderer.render(File.read(file)).html_safe
-  end
-
-  private
-
-  def renderer
-    Redcarpet::Markdown.new(Redcarpet::Render::HTML)
-  end
-
-  def file
-    Rails.root.join("CODE_OF_CONDUCT.md")
   end
 end

--- a/app/models/cold_message.rb
+++ b/app/models/cold_message.rb
@@ -1,4 +1,4 @@
-ColdMessage = Struct.new(:message, :show_hiring_fee_terms, :tips, keyword_init: true) do
+ColdMessage = Struct.new(:message, :show_hiring_fee_terms, keyword_init: true) do
   def developer
     message.conversation.developer
   end

--- a/app/models/markdown_renderer.rb
+++ b/app/models/markdown_renderer.rb
@@ -1,8 +1,12 @@
 class MarkdownRenderer
-  private attr_reader :view_directory
+  private attr_reader :view_directory, :absolute_path
 
-  def initialize(view_directory)
-    @view_directory = view_directory
+  def initialize(view_directory_or_absolute_path, localize: true)
+    if localize
+      @view_directory = view_directory_or_absolute_path
+    else
+      @absolute_path = view_directory_or_absolute_path
+    end
   end
 
   def render
@@ -16,6 +20,14 @@ class MarkdownRenderer
   end
 
   def file
+    if view_directory.present?
+      localized_file
+    elsif absolute_path.present?
+      Rails.root.join(absolute_path)
+    end
+  end
+
+  def localized_file
     translated_file = file_path(I18n.locale)
     if File.exist?(translated_file)
       translated_file

--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -25,11 +25,11 @@
 
       <div class="mt-8 lg:mt-0 lg:col-span-3">
         <div class="prose prose-lg prose-gray text-gray-500 max-w-prose mx-auto lg:max-w-none">
-          <%== @hero %>
+          <%= render MarkdownComponent.about_hero %>
         </div>
 
         <div class="mt-8 prose prose-gray text-gray-500 mx-auto lg:max-w-none lg:row-start-1 lg:col-start-1">
-          <%== @body %>
+          <%= render MarkdownComponent.about_body %>
         </div>
       </div>
     </div>

--- a/app/views/cold_messages/new.html.erb
+++ b/app/views/cold_messages/new.html.erb
@@ -30,7 +30,7 @@
           <% end %>
 
           <div class="prose prose-sm mt-10 md:mt-20">
-            <%== @cold_message.tips %>
+            <%= render MarkdownComponent.messaging_tips %>
           </div>
         </div>
       </div>

--- a/app/views/conducts/show.html.erb
+++ b/app/views/conducts/show.html.erb
@@ -1,7 +1,7 @@
 <div class="overflow-hidden max-w-5xl mx-auto">
   <div class="relative max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
     <div class="mt-8 max-w-prose prose prose-gray text-gray-500 mx-auto">
-      <%= @body %>
+      <%= render MarkdownComponent.code_of_coduct %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Moves all markdown rendering to `MarkdownComponent` to remove "logic" from controllers.

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~