### PR TITLE
Fix flash messages for bussiness and developer

### DIFF
--- a/app/controllers/analytics/events_controller.rb
+++ b/app/controllers/analytics/events_controller.rb
@@ -8,6 +8,7 @@ module Analytics
         flash[:event] = {goal: event.goal, value: event.value}
       end
 
+      flash.keep
       redirect_to event.url
     end
   end

--- a/test/integration/businesses_test.rb
+++ b/test/integration/businesses_test.rb
@@ -45,9 +45,20 @@ class BusinessesTest < ActionDispatch::IntegrationTest
       end
     end
 
+    last_event = Analytics::Event.last
+
     assert user.business.avatar.attached?
-    assert_redirected_to Analytics::Event.last
+    assert_redirected_to last_event
     assert_equal Analytics::Event.last.url, developers_path
+
+    follow_redirect!
+
+    assert_redirected_to last_event.url
+
+    follow_redirect!
+
+    assert_not_nil flash[:event]
+    assert_not_nil flash[:notice]
   end
 
   test "successful business creation with a stored location" do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -130,7 +130,18 @@ class DevelopersTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_redirected_to analytics_event_path(Analytics::Event.last)
+    last_event = Analytics::Event.last
+
+    assert_redirected_to analytics_event_path(last_event)
+
+    follow_redirect!
+
+    assert_redirected_to last_event.url
+
+    follow_redirect!
+
+    assert_not_nil flash[:event]
+    assert_not_nil flash[:notice]
   end
 
   test "create with nested attributes" do


### PR DESCRIPTION
I was digging and I found that the flash messages don't show because both Developers and Businesses controllers make two redirects. So in the first redirect it's set the notice message and then redirect again in EventsController with the new values for flash event. So because it's made a second request the notice message is lost.

For fix the bug I added flash.now in EventsController to preserve the previos flash messages for the next request. Also added more assert tests.

Fix #442 