### PR TITLE
Rename notifications in db to reflect model name

### DIFF
--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -1,3 +1,22 @@
 desc "These tasks are meant to be run once then removed"
 namespace :backfills do
+  task notifications: :environment do
+    Notification.where(type: "NewDeveloperProfileNotification")
+      .update_all(type: Admin::NewDeveloperNotification.to_s)
+
+    Notification.where(type: "NewBusinessNotification")
+      .update_all(type: Admin::NewBusinessNotification.to_s)
+
+    Notification.where(type: "NewConversationNotification")
+      .update_all(type: Admin::NewConversationNotification.to_s)
+
+    Notification.where(type: "InvisiblizeDeveloperNotification")
+      .update_all(type: Developers::InvisiblizeNotification.to_s)
+
+    Notification.where(type: "PotentialHireNotification")
+      .update_all(type: Admin::PotentialHireNotification.to_s)
+
+    Notification.where(type: "StaleDeveloperNotification")
+      .update_all(type: Developers::ProfileReminderNotification.to_s)
+  end
 end


### PR DESCRIPTION
This PR addresses an issue where existing notifications could reference a model that no longer exists. This was introduced in #458 where some notifications were renamed. Noticed needs the `type` to match the model name so it can deserialize to an instance. 

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~