### PR TITLE
Don't notify devs to update if they aren't looking

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -59,6 +59,7 @@ class Developer < ApplicationRecord
   scope :available_first, -> { where.not(available_on: nil).order(:available_on) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :visible, -> { where.not(search_status: :invisible).or(where(search_status: nil)) }
+  scope :actively_looking_or_open, -> { where(search_status: [:actively_looking, :open, nil]) }
   scope :featured, -> { where("featured_at >= ?", 1.week.ago).order(featured_at: :desc) }
 
   def visible?

--- a/app/queries/stale_developers_query.rb
+++ b/app/queries/stale_developers_query.rb
@@ -2,7 +2,9 @@ class StaleDevelopersQuery
   EARLIEST_TIME = 30.days.ago.beginning_of_day
 
   def stale_and_not_recently_notified
-    Developer.where(updated_at: ..EARLIEST_TIME).where(no_recent_notifications)
+    Developer.actively_looking_or_open
+      .where(updated_at: ..EARLIEST_TIME)
+      .where(no_recent_notifications)
   end
 
   private
@@ -24,7 +26,7 @@ class StaleDevelopersQuery
   end
 
   def stale_notification_type
-    notifications_table[:type].eq("Developers::ProfileReminderNotification")
+    notifications_table[:type].eq(Developers::ProfileReminderNotification.name)
   end
 
   def recently_created

--- a/test/queries/stale_developers_query_test.rb
+++ b/test/queries/stale_developers_query_test.rb
@@ -27,4 +27,21 @@ class StaleDevelopersQueryTest < ActiveSupport::TestCase
     stale_developer.touch
     assert_empty StaleDevelopersQuery.new.stale_and_not_recently_notified
   end
+
+  test ".stale_and_not_recently_notified ignores invisible and developers not looking" do
+    travel_to(31.days.ago)
+    developer = create_developer(search_status: nil)
+    travel_back
+
+    records = StaleDevelopersQuery.new.stale_and_not_recently_notified
+    assert_includes records, developer
+
+    developer.search_status = :invisible
+    developer.save(touch: false) # Don't update #updated_at.
+    refute_includes StaleDevelopersQuery.new.stale_and_not_recently_notified, developer
+
+    developer.search_status = :not_interested
+    developer.save(touch: false) # Don't update #updated_at.
+    refute_includes StaleDevelopersQuery.new.stale_and_not_recently_notified, developer
+  end
 end


### PR DESCRIPTION
This PR restricts the profile update reminder notification to developers who are actively or passively looking. It no longer sends an email to folks who are invisible nor not interested.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~