### PR TITLE
Apology email for double send

### DIFF
--- a/app/mailers/developer_mailer.rb
+++ b/app/mailers/developer_mailer.rb
@@ -47,4 +47,13 @@ class DeveloperMailer < ApplicationMailer
       subject: t(".subject")
     )
   end
+
+  def apology
+    @developer = params[:developer]
+
+    mail(
+      to: @developer.user.email,
+      subject: "Apologies - you may have gotten 2 emails from railsdevs"
+    )
+  end
 end

--- a/app/views/developer_mailer/apology.html.erb
+++ b/app/views/developer_mailer/apology.html.erb
@@ -1,0 +1,5 @@
+<p>Hey <%= @developer.first_name %>,</p>
+<p>I'm Joe, the solo-founder of railsdevs. You may have received multiple emails asking if your profile is up to date.</p>
+<p>You should have only gotten one. Yesterday I introduced a bug that caused this to occur. I <a href="https://github.com/joemasilotti/railsdevs.com/pull/463">fixed it this morning</a> but not before the emails went out.</p>
+<p>I apologize for clogging your inbox and sending <i>another</i> email.</p>
+<%= render "shared/signature" %>

--- a/app/views/developer_mailer/apology.text.erb
+++ b/app/views/developer_mailer/apology.text.erb
@@ -1,0 +1,11 @@
+Hey <%= @developer.first_name %>,
+
+I'm Joe, the solo-founder of railsdevs. You may have received multiple emails asking if your profile is up to date.
+
+You should have only gotten one. Yesterday I introduced a bug that caused this to occur. I fixed it this morning but not before the emails went out.
+
+Bug fix: https://github.com/joemasilotti/railsdevs.com/pull/463
+
+I apologize for clogging your inbox and sending another email.
+
+<%= render "shared/signature" %>

--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -1,3 +1,13 @@
 desc "These tasks are meant to be run once then removed"
 namespace :backfills do
+  task apology: :environment do
+    Developer.find_each do |developer|
+      notifications = developer.user.notifications
+        .where(type: Developers::ProfileReminderNotification.name)
+      if notifications.count > 1
+        notifications.last.destroy
+        DeveloperMailer.with(developer:).apology.deliver_later
+      end
+    end
+  end
 end

--- a/test/mailers/previews/developer_mailer_preview.rb
+++ b/test/mailers/previews/developer_mailer_preview.rb
@@ -17,4 +17,8 @@ class DeveloperMailerPreview < ActionMailer::Preview
   def first_message
     DeveloperMailer.with(developer: Developer.first).first_message
   end
+
+  def apology
+    DeveloperMailer.with(developer: Developer.first).apology
+  end
 end


### PR DESCRIPTION
Due to #463, I sent the profile update reminder notification _again_ today to everyone that got it yesterday. This PR notifies those folks with an apology email.