### PR TITLE
Action Mailbox tweaks

### DIFF
--- a/app/mailboxes/messages_mailbox.rb
+++ b/app/mailboxes/messages_mailbox.rb
@@ -2,7 +2,7 @@ class MessagesMailbox < ApplicationMailbox
   rescue_from(ActiveRecord::RecordNotFound) { bounced! }
 
   def process
-    message = Message.new(conversation:, sender:, body: mail_body)
+    message = Message.new(conversation:, sender:, body:)
     if MessagePolicy.new(user, message).create?
       message.save_and_notify
       conversation.mark_notifications_as_read(user)
@@ -37,11 +37,7 @@ class MessagesMailbox < ApplicationMailbox
     mail.to.first
   end
 
-  def mail_body
-    if mail.multipart?
-      mail.parts.first.body.decoded
-    else
-      mail.decoded
-    end
+  def body
+    InboundEmailContent.new(mail).content
   end
 end

--- a/app/mailboxes/messages_mailbox.rb
+++ b/app/mailboxes/messages_mailbox.rb
@@ -1,5 +1,4 @@
 class MessagesMailbox < ApplicationMailbox
-  rescue_from(ActiveSupport::MessageVerifier::InvalidSignature) { bounced! }
   rescue_from(ActiveRecord::RecordNotFound) { bounced! }
 
   def process
@@ -15,8 +14,7 @@ class MessagesMailbox < ApplicationMailbox
   private
 
   def conversation
-    @conversation ||= user.conversations
-      .find_signed!(signed_conversation_id, purpose: :message)
+    @conversation ||= user.conversations.find_by!(inbound_email_token: conversation_token)
   end
 
   def user
@@ -31,7 +29,7 @@ class MessagesMailbox < ApplicationMailbox
     end
   end
 
-  def signed_conversation_id
+  def conversation_token
     recipient.match(/^message-(.*)@/).captures.first
   end
 

--- a/app/mailers/message_mailer.rb
+++ b/app/mailers/message_mailer.rb
@@ -10,12 +10,12 @@ class MessageMailer < ApplicationMailer
     @sender = message.sender.name
     @body = message.body
 
-    signed_id = message.conversation.signed_id(purpose: :message)
+    conversation_token = message.conversation.inbound_email_token
 
     mail(
       to: @recipient.email,
       subject: @notification.email_subject,
-      reply_to: "message-#{signed_id}@inbound.railsdevs.com"
+      reply_to: "message-#{conversation_token}@inbound.railsdevs.com"
     )
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,4 +1,6 @@
 class Conversation < ApplicationRecord
+  has_secure_token :inbound_email_token
+
   belongs_to :developer
   belongs_to :business
 

--- a/app/models/inbound_email_content.rb
+++ b/app/models/inbound_email_content.rb
@@ -1,0 +1,21 @@
+class InboundEmailContent
+  private attr_reader :mail
+
+  def initialize(mail)
+    @mail = mail
+  end
+
+  def content
+    body.split(/^.*@railsdevs\.com>? wrote:$/).first.squish
+  end
+
+  private
+
+  def body
+    if mail.multipart?
+      mail.parts.first.body.decoded
+    else
+      mail.decoded
+    end
+  end
+end

--- a/db/migrate/20220610180608_add_inbound_email_token_to_conversations.rb
+++ b/db/migrate/20220610180608_add_inbound_email_token_to_conversations.rb
@@ -1,0 +1,7 @@
+class AddInboundEmailTokenToConversations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :inbound_email_token, :string
+    Conversation.find_each.map(&:regenerate_inbound_email_token)
+    add_index :conversations, :inbound_email_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_09_190652) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_10_180608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,8 +80,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_190652) do
     t.datetime "updated_at", null: false
     t.datetime "developer_blocked_at"
     t.datetime "business_blocked_at"
+    t.string "inbound_email_token"
     t.index ["business_id"], name: "index_conversations_on_business_id"
     t.index ["developer_id"], name: "index_conversations_on_developer_id"
+    t.index ["inbound_email_token"], name: "index_conversations_on_inbound_email_token", unique: true
   end
 
   create_table "developers", force: :cascade do |t|

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -1,3 +1,4 @@
 one:
   developer: prospect
   business: subscriber
+  inbound_email_token: EMAIL-TOKEN

--- a/test/mailboxes/messages_mailbox_test.rb
+++ b/test/mailboxes/messages_mailbox_test.rb
@@ -20,6 +20,15 @@ class MessagesMailboxTest < ActionMailbox::TestCase
     assert_equal @conversation.developer, Message.last.sender
   end
 
+  test "only text in the actual sent email is used for the message body" do
+    body = "Message content\n
+      On June 10, 2022, notifications@railsdevs.com wrote:\n
+      Previous message content"
+
+    receive_inbound_email(body:, from: @conversation.business)
+    assert_equal "Message content", Message.last.body
+  end
+
   test "invalid conversation signatures bounce" do
     email = receive_inbound_email(
       from: @conversation.developer,

--- a/test/mailboxes/messages_mailbox_test.rb
+++ b/test/mailboxes/messages_mailbox_test.rb
@@ -23,7 +23,7 @@ class MessagesMailboxTest < ActionMailbox::TestCase
   test "invalid conversation signatures bounce" do
     email = receive_inbound_email(
       from: @conversation.developer,
-      valid_signed_id: false
+      valid_token: false
     )
 
     assert email.bounced?
@@ -32,7 +32,7 @@ class MessagesMailboxTest < ActionMailbox::TestCase
   test "invalid users bounce" do
     email = receive_inbound_email(
       from: developers(:one),
-      valid_signed_id: false
+      valid_token: false
     )
 
     assert email.bounced?
@@ -47,16 +47,12 @@ class MessagesMailboxTest < ActionMailbox::TestCase
     end
   end
 
-  def receive_inbound_email(from:, body: "Email body.", valid_signed_id: true)
-    id = valid_signed_id ? conversation_signed_id : "invalid-id"
+  def receive_inbound_email(from:, body: "Email body.", valid_token: true)
+    token = valid_token ? @conversation.inbound_email_token : "invalid-token"
 
     receive_inbound_email_from_mail \
-      to: "message-#{id}@example.com",
+      to: "message-#{token}@example.com",
       from: from.user.email,
       body:
-  end
-
-  def conversation_signed_id
-    @conversation.signed_id(purpose: :message)
   end
 end


### PR DESCRIPTION
This PR addresses two issues with the existing implementation of Action Mailbox.

First, the Reply-To emails were _way_ too long. Moving from `signed_id` to `has_secure_token` drops the length of the email from 180 to 54. For example,

```
signed_id:        message-eyJfcmFpbHMiOnsibWVzc2FnZSI6Ik1RPT0iLCJleHAiOm51bGwsInB1ciI6ImNvbnZlcnNhdGlvbiJ9fQ==--91cf9a20f60c144135b09ce351ce37c9412f56ff10acdda4f696cb991b83f985@inbound.railsdevs.com
has_secure_token: message-h4CA8ygp1vQ7nSnLsY8MTDR3@inbound.railsdevs.com
```

Second, it makes a first attempt at stripping out the email content of the email being replied to. Said another way, it tries to only use what the user wrote instead of what the email client added to the bottom. Without this change the email response might include the original email beneath the actual reply.

This most definitely doesn't cover all edge cases nor email clients, but it is a start. And all the logic is in `InboundEmailContent` for future improvements.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
