### PR TITLE
Fix issue with infinite scrolling on `/developers`

### DIFF
--- a/app/policies/developers/query_policy.rb
+++ b/app/policies/developers/query_policy.rb
@@ -12,6 +12,7 @@ module Developers
 
     def default_attributes
       [
+        :page,
         :include_not_interested,
         :sort,
         role_levels: [],

--- a/test/system/scroll_test.rb
+++ b/test/system/scroll_test.rb
@@ -1,6 +1,7 @@
 require "application_system_test_case"
 
 class ScrollTest < ApplicationSystemTestCase
+  include DevelopersHelper
   include Devise::Test::IntegrationHelpers
 
   test "scrolling to the message form at the bottom of the conversation page on page load" do
@@ -19,17 +20,17 @@ class ScrollTest < ApplicationSystemTestCase
   end
 
   test "scrolling to bottom of of the developers page loads more results" do
-    # Create some more developers for pagination results to load
-    (1..20).each do |n|
-      developer = developers(:one).dup
-      developer.name = "Developer #{n}"
-      developer.hero = "Hero: #{n}"
-      developer.save(validate: false)
-    end
+    # Create more developers to trigger pagination.
+    20.times { create_developer }
 
     visit developers_path
-    # Scroll to bottom of page
-    page.execute_script "window.scrollBy(0,10000)"
+    refute_text "Developer number one"
+
+    scroll_to_bottom_of_page
     assert_text "Developer number one"
+  end
+
+  def scroll_to_bottom_of_page
+    page.execute_script "window.scrollBy(0,10000)"
   end
 end

--- a/test/system/scroll_test.rb
+++ b/test/system/scroll_test.rb
@@ -17,4 +17,19 @@ class ScrollTest < ApplicationSystemTestCase
 
     refute find("#message_body").obscured?
   end
+
+  test "scrolling to bottom of of the developers page loads more results" do
+    # Create some more developers for pagination results to load
+    (1..20).each do |n|
+      developer = developers(:one).dup
+      developer.name = "Developer #{n}"
+      developer.hero = "Hero: #{n}"
+      developer.save(validate: false)
+    end
+
+    visit developers_path
+    # Scroll to bottom of page
+    page.execute_script "window.scrollBy(0,10000)"
+    assert_text "Developer number one"
+  end
 end


### PR DESCRIPTION
`:page` was not an allowed paramater, this broke infinite scrolling.
This PR should it as an allowed paramater and also add a system test

Closes #486 

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)