### PR TITLE
Move the hard-coded strings in HiringFeeComponent to the locale file

### DIFF
--- a/app/components/businesses/hiring_fee_component.rb
+++ b/app/components/businesses/hiring_fee_component.rb
@@ -21,11 +21,11 @@ module Businesses
     end
 
     def subject
-      t(".subject.hired")
+      t(".subject")
     end
 
     def body
-      t(".body.hired", developer:)
+      t(".body", developer:)
     end
   end
 end

--- a/app/components/businesses/hiring_fee_component.rb
+++ b/app/components/businesses/hiring_fee_component.rb
@@ -25,7 +25,7 @@ module Businesses
     end
 
     def body
-      t(".body.hired", developer: developer)
+      t(".body.hired", developer:)
     end
   end
 end

--- a/app/components/businesses/hiring_fee_component.rb
+++ b/app/components/businesses/hiring_fee_component.rb
@@ -21,11 +21,11 @@ module Businesses
     end
 
     def subject
-      "I hired a developer via railsdevs"
+      t(".subject.hired")
     end
 
     def body
-      "Hi Joe, I hired #{developer} via railsdevs and would like to coordinate paying the fee. Their starting salary is: "
+      t(".body.hired", developer: developer)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,12 +131,12 @@ en:
       updating: Updating...
       your_business_profile: Your business profile
     hiring_fee_component:
-      cta: Pay hiring fee
-      title: Have you hired %{developer}?
-      subject:
-        hired: I hired a developer via railsdevs
       body:
         hired: 'Hi Joe, I hired %{developer} via railsdevs and would like to coordinate paying the fee. Their starting salary is: '
+      cta: Pay hiring fee
+      subject:
+        hired: I hired a developer via railsdevs
+      title: Have you hired %{developer}?
     primary_action_component:
       edit: Edit
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,11 +131,9 @@ en:
       updating: Updating...
       your_business_profile: Your business profile
     hiring_fee_component:
-      body:
-        hired: 'Hi Joe, I hired %{developer} via railsdevs and would like to coordinate paying the fee. Their starting salary is: '
+      body: 'Hi Joe, I hired %{developer} via railsdevs and would like to coordinate paying the fee. Their starting salary is: '
       cta: Pay hiring fee
-      subject:
-        hired: I hired a developer via railsdevs
+      subject: I hired a developer via railsdevs
       title: Have you hired %{developer}?
     primary_action_component:
       edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,10 @@ en:
     hiring_fee_component:
       cta: Pay hiring fee
       title: Have you hired %{developer}?
+      subject:
+        hired: I hired a developer via railsdevs
+      body:
+        hired: 'Hi Joe, I hired %{developer} via railsdevs and would like to coordinate paying the fee. Their starting salary is: '
     primary_action_component:
       edit: Edit
     show:


### PR DESCRIPTION
This trivial PR should move the hard-coded strings in Conversations::HiringFeeComponent to the locale file.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
