### PR TITLE
Fix mobile sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### June
 
+* June 13 - Fix sorting on mobile - #495
 * June 13 - Remove `turbo: false` from all non-Stripe forms - #483
 * June 9 - Order conversations by most recent message, not when they were started
 * June 8 - Add text search for developers (for paid accounts) - #470 @troyizzle

--- a/app/components/developers/query_mobile_component.html.erb
+++ b/app/components/developers/query_mobile_component.html.erb
@@ -11,7 +11,6 @@
           </button>
         </div>
 
-        <%= form.hidden_field :sort, value: query.sort if query.sort %>
         <div class="mx-4 pb-4">
           <%= form.label :search_query, t("developers.query_component.search_query_label"), class: "block text-sm font-medium text-gray-700" %>
           <%= render Users::PaywalledComponent.new(user: user, paywalled: nil, size: :small, title: t("developers.query_component.paywalled_search.title")) do %>

--- a/app/components/developers/query_sort_button_component.html.erb
+++ b/app/components/developers/query_sort_button_component.html.erb
@@ -5,7 +5,7 @@
   </button>
 
   <div data-toggle-target="element" class="hidden origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-2xl bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-10" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
-    <%= render SortButtonComponent.new(title: t(".sort.newest"), name: :sort, value: :newest, active: sort == :newest, form_id: form_id) %>
-    <%= render SortButtonComponent.new(title: t(".sort.availability"), name: :sort, value: :availability, active: sort == :availability, form_id: form_id) %>
+    <%= render SortButtonComponent.new(title: t(".sort.newest"), name: :sort, value: :newest, active: sort == :newest, form_id: form_id, scope: scope) %>
+    <%= render SortButtonComponent.new(title: t(".sort.availability"), name: :sort, value: :availability, active: sort == :availability, form_id: form_id, scope: scope) %>
   </div>
 </div>

--- a/app/components/developers/query_sort_button_component.rb
+++ b/app/components/developers/query_sort_button_component.rb
@@ -1,13 +1,14 @@
 module Developers
   class QuerySortButtonComponent < ApplicationComponent
-    attr_reader :query, :user, :form_id
+    attr_reader :query, :user, :form_id, :scope
 
     delegate :sort, :search_query, to: :query
 
-    def initialize(query:, user:, form_id:)
+    def initialize(query:, user:, form_id:, scope: nil)
       @query = query
       @user = user
       @form_id = form_id
+      @scope = scope
     end
   end
 end

--- a/app/components/sort_button_component.rb
+++ b/app/components/sort_button_component.rb
@@ -1,12 +1,21 @@
 class SortButtonComponent < ApplicationComponent
-  attr_reader :title, :name, :value, :form_id
+  attr_reader :title, :value, :form_id
 
-  def initialize(title:, name:, value:, active:, form_id:)
+  def initialize(title:, name:, value:, active:, form_id:, scope: nil)
     @title = title
     @name = name
     @value = value
     @active = active
     @form_id = form_id
+    @scope = scope
+  end
+
+  def name
+    if @scope.present?
+      "#{@scope}[#{@name}]"
+    else
+      @name
+    end
   end
 
   def dynamic_classes

--- a/app/components/sort_button_component.rb
+++ b/app/components/sort_button_component.rb
@@ -10,6 +10,6 @@ class SortButtonComponent < ApplicationComponent
   end
 
   def dynamic_classes
-    !!@active ? "font-medium text-gray-900" : "text-gray-700"
+    !!@active ? "font-medium text-gray-900" : "font-normal text-gray-700"
   end
 end

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -16,7 +16,7 @@
       </div>
 
       <div class="flex justify-end items-center md:hidden">
-        <%= render Developers::QuerySortButtonComponent.new(query: @query, user: current_user, form_id: "developer-filters-mobile") %>
+        <%= render Developers::QuerySortButtonComponent.new(query: @query, user: current_user, form_id: "developer-filters-mobile", scope: "developer-filters-mobile") %>
         <button type="button" data-action="toggle#toggle" class="p-2 -m-2 ml-4 sm:ml-6 text-gray-400 hover:text-gray-500" aria-expanded="false">
           <%= inline_svg_tag "icons/solid/filter.svg", class: "h-5 w-5" %>
           <span class="sr-only"><%= t("developers.query_component.filters") %></span>


### PR DESCRIPTION
This PR fixes mobile sorting by passing along the scope of the form ID down to `SortButtonComponent`. Before, the sorting button submitted the form with the `sort` parameter in the root params. But the mobile form would override that from the params manipulation on `app/controllers/developers_controller.rb:50`.

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)