### PR TITLE
Minor refactors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,7 @@ group :development, :test do
 end
 
 group :development do
-  # Point to GitHub until https://github.com/Shopify/erb-lint/pull/235 is released.
-  gem "erb_lint", require: false, github: "Shopify/erb-lint"
+  gem "erb_lint", "~> 0.1.2", require: false
   gem "hotwire-livereload"
   gem "redis"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,4 @@
 GIT
-  remote: https://github.com/Shopify/erb-lint.git
-  revision: 02fb0e948d57fca7eed050ca7713436ebb8ff4f9
-  specs:
-    erb_lint (0.1.1)
-      activesupport
-      better_html (~> 1.0.7)
-      html_tokenizer
-      parser (>= 2.7.1.4)
-      rainbow
-      rubocop
-      smart_properties
-
-GIT
   remote: https://github.com/pay-rails/pay.git
   revision: 4f4a726051bed3f88f6f74541cc2cdd8b600afb0
   ref: 4f4a726051bed3f88f6f74541cc2cdd8b600afb0
@@ -157,6 +144,14 @@ GEM
     digest (3.1.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    erb_lint (0.1.2)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.10.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
@@ -459,7 +454,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.0)
   devise (~> 4.8.1)
   devise-i18n (~> 1.10.1)
-  erb_lint!
+  erb_lint (~> 0.1.2)
   faker
   fathom_api (~> 0.1.2)
   geocoder (~> 1.7.3)

--- a/app/notifications/README.md
+++ b/app/notifications/README.md
@@ -13,7 +13,17 @@ Notification.where(type: "NewDeveloperProfileNotification")
 
 This can be added to `lib/tasks/backfills.rake` as a new task and manually run via the Heroku CLI.
 
-## iOS Simulator
+## iOS notifications (APNs)
+
+To send a push notification via APNs to iOS devices, add the following to the notification class.
+
+```ruby
+include IosNotification
+```
+
+Also, make sure that the following methods are implemented: `#title`, `#ios_subject`, and `#url`.
+
+### iOS Simulator
 
 You can send notifications to the iOS simulator with a .apns file.
 

--- a/app/notifications/ios_notification.rb
+++ b/app/notifications/ios_notification.rb
@@ -1,4 +1,10 @@
 module IosNotification
+  extend ActiveSupport::Concern
+
+  included do
+    deliver_by :ios, format: :ios_format, cert_path: :ios_cert_path, development: :development?
+  end
+
   def ios_format(apn)
     apn.alert = {title:, body: ios_subject}
     apn.custom_payload = {url:}

--- a/app/notifications/ios_notification.rb
+++ b/app/notifications/ios_notification.rb
@@ -24,6 +24,6 @@ module IosNotification
   end
 
   def cleanup_device_token(token:, platform:)
-    NotificationToken.find_by(token: token.token, platform:)&.destroy
+    NotificationToken.where(token: token.token, platform:).destroy_all
   end
 end

--- a/app/notifications/new_message_notification.rb
+++ b/app/notifications/new_message_notification.rb
@@ -3,7 +3,6 @@ class NewMessageNotification < ApplicationNotification
 
   deliver_by :database
   deliver_by :email, mailer: "MessageMailer", method: :new_message
-  deliver_by :ios, format: :ios_format, cert_path: :ios_cert_path, development: :development?
 
   param :message
   param :conversation

--- a/test/notifications/new_message_notification_test.rb
+++ b/test/notifications/new_message_notification_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class NewMessageNotificationTest < ActiveSupport::TestCase
+  test "implements required methods for iOS notifications" do
+    message = messages(:from_business)
+    conversation = conversations(:one)
+
+    notification = NewMessageNotification.with(message:, conversation:)
+
+    assert_respond_to notification, "title"
+    assert_respond_to notification, "ios_subject"
+    assert_respond_to notification, "url"
+  end
+end


### PR DESCRIPTION
* Move growing iOS delivery method to module to keep code contained. Now, `include IosNotification` to send it via APNs. Document and add a test.
* Destroy all matching notification tokens (in case of duplicates) instead of just the first one.
* Point erb-lint back to release now that [PR is released](https://github.com/Shopify/erb-lint/issues/244#issuecomment-1157081768).

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~