### PR TITLE
Note hiring fees on `/open/revenue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### June
 
+* June 16 - Note hiring fees on `/open/revenue` #501
 * June 14 - Add support for iOS app powered by Turbo Native - #496
 * June 13 - Fix sorting on mobile - #495
 * June 13 - Add empty state for `/developers` - #484 @bensheldon

--- a/app/models/open_startup/reporting.rb
+++ b/app/models/open_startup/reporting.rb
@@ -46,9 +46,13 @@ module OpenStartup
       Revenue.transaction do
         Revenue.delete_all
 
-        StripeTransaction.charge.group_by_month(:created).group(:description).sum(:amount).each do |group, amount|
+        monthly_charges = StripeTransaction.charge
+          .group_by_month(:created).group(:description)
+          .sum(:amount)
+        monthly_charges.each do |(occurred_on, description), amount|
           next if amount.zero?
-          Revenue.create!(occurred_on: group.first, description: group.last.pluralize, amount:)
+          description = "Hiring fees" if description == "Payment for Invoice"
+          Revenue.create!(occurred_on:, description: description.pluralize, amount:)
         end
       end
     end

--- a/test/models/open_startup/reporting_test.rb
+++ b/test/models/open_startup/reporting_test.rb
@@ -9,7 +9,7 @@ class OpenStartup::ReportingTest < ActiveSupport::TestCase
       charge(amount: 2000, created: january, description: "New subscription"),
       charge(amount: 4000, created: february, description: "New subscription"),
       charge(amount: 5000, created: february, description: "Update subscription"),
-      charge(amount: 9900, created: february, description: "Payment for Invoice"),
+      charge(amount: 9900, created: february, description: "Payment for Invoice")
     ]
 
     refresh_metrics

--- a/test/models/open_startup/reporting_test.rb
+++ b/test/models/open_startup/reporting_test.rb
@@ -8,16 +8,18 @@ class OpenStartup::ReportingTest < ActiveSupport::TestCase
       charge(amount: 1000, created: january, description: "New subscription"),
       charge(amount: 2000, created: january, description: "New subscription"),
       charge(amount: 4000, created: february, description: "New subscription"),
-      charge(amount: 5000, created: february, description: "Update subscription")
+      charge(amount: 5000, created: february, description: "Update subscription"),
+      charge(amount: 9900, created: february, description: "Payment for Invoice"),
     ]
 
     refresh_metrics
 
-    assert_equal OpenStartup::Revenue.pluck(:occurred_on, :description, :amount), [
-      [Date.new(2022, 1, 1), "New subscriptions", 30],
-      [Date.new(2022, 2, 1), "New subscriptions", 40],
-      [Date.new(2022, 2, 1), "Update subscriptions", 50]
-    ]
+    revenue = OpenStartup::Revenue.pluck(:occurred_on, :description, :amount)
+    assert_equal 4, revenue.count
+    assert_includes revenue, [Date.new(2022, 1, 1), "New subscriptions", 30]
+    assert_includes revenue, [Date.new(2022, 2, 1), "New subscriptions", 40]
+    assert_includes revenue, [Date.new(2022, 2, 1), "Hiring fees", 99]
+    assert_includes revenue, [Date.new(2022, 2, 1), "Update subscriptions", 50]
   end
 
   test "refreshes Expense records (grouped by month and merged with additional fees) and adds manual expenses" do


### PR DESCRIPTION
railsdevs [officially placed a Rails developer with a full-time role](https://twitter.com/joemasilotti/status/1537515187091058688)! Now we need a way to show that 10% hiring fee in the Open Startup dashboard.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)