### PR TITLE
Issue 503 alllow invisible developers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### June
 
+* June 18 - Admins can view invisible developer profiles - #505 @kaushikhande
 * June 17 - Read indicators for messages - #485 @troyizzle
 * June 16 - Note hiring fees on `/open/revenue` #501
 * June 14 - Add support for iOS app powered by Turbo Native - #496

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### June
 
-* June 18 - Admins can view invisible developer profiles - #505 @kaushikhande
+* June 19 - Admins can view invisible developer profiles - #505 @kaushikhande
 * June 17 - Read indicators for messages - #485 @troyizzle
 * June 16 - Note hiring fees on `/open/revenue` #501
 * June 14 - Add support for iOS app powered by Turbo Native - #496

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,7 +35,7 @@ class ApplicationPolicy
   end
 
   def admin?
-    user.admin?
+    user&.admin?
   end
 
   def record_owner?

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -4,6 +4,6 @@ class DeveloperPolicy < ApplicationPolicy
   end
 
   def show?
-    record.visible? || record_owner? || user&.admin?
+    record.visible? || record_owner? || admin?
   end
 end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -4,6 +4,6 @@ class DeveloperPolicy < ApplicationPolicy
   end
 
   def show?
-    record.visible? || record_owner? || user.admin?
+    record.visible? || record_owner? || user&.admin?
   end
 end

--- a/app/policies/developer_policy.rb
+++ b/app/policies/developer_policy.rb
@@ -4,6 +4,6 @@ class DeveloperPolicy < ApplicationPolicy
   end
 
   def show?
-    record.visible? || record_owner?
+    record.visible? || record_owner? || user.admin?
   end
 end

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -38,6 +38,16 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test "admin can see invisible developer profile" do
+    developer = create_developer(search_status: :invisible)
+    user = users(:admin)
+    sign_in user
+
+    get developer_path(developer)
+
+    assert_response :ok
+  end
+
   test "developers are sorted newest first" do
     create_developer(hero: "Oldest")
     create_developer(hero: "Newest")

--- a/test/policies/developer_policy_test.rb
+++ b/test/policies/developer_policy_test.rb
@@ -26,6 +26,12 @@ class DeveloperPolicyTest < ActiveSupport::TestCase
     refute DeveloperPolicy.new(user, developer).show?
   end
 
+  test "admin can view another's invisible developer profile" do
+    user = users(:admin)
+    developer = create_invisible_developer!
+    assert DeveloperPolicy.new(user, developer).show?
+  end
+
   def create_invisible_developer!
     Developer.create!(developer_attributes.merge(search_status: :invisible))
   end


### PR DESCRIPTION
 Admins can view invisible developer profiles #503 
- [x]  Allow admins to view invisible developer profiles
## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
