### PR TITLE
Naming Things - Data migration and scaffolding for Account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  before_action -> { Current.user = current_user }
   around_action :set_locale
   helper_method :resolve_locale
   helper_method :turbo_native_app?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,8 @@
+class Account < ApplicationRecord
+  has_many :account_memberships
+  has_many :users, through: :account_memberships
+
+  delegate :name, to: :profile
+
+  delegated_type :profile, types: %w[Business Developer]
+end

--- a/app/models/account_membership.rb
+++ b/app/models/account_membership.rb
@@ -1,0 +1,6 @@
+class AccountMembership < ApplicationRecord
+  belongs_to :user
+  belongs_to :account
+
+  enum role: %w[admin]
+end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -2,6 +2,7 @@ class Business < ApplicationRecord
   include Avatarable
   include Businesses::Notifications
   include PersonName
+  include Profile
 
   enum :developer_notifications, %i[no daily weekly], default: :no, suffix: true
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,18 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+
+  def account
+    return nil unless account_id.present?
+    @account ||= user&.accounts&.find(account_id)
+  end
+
+  private
+
+  def account_id
+    session[:account_id] ||= default_account&.id
+  end
+
+  def default_account
+    user.business || user.developer
+  end
+end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -5,6 +5,7 @@ class Developer < ApplicationRecord
   include HasSocialProfiles
   include PersonName
   include PgSearch::Model
+  include Profile
 
   enum search_status: {
     actively_looking: 1,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,6 @@
+module Profile
+  extend ActiveSupport::Concern
+
+  included do
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
   has_many :notification_tokens
   has_many :notifications, as: :recipient, dependent: :destroy
+  has_many :account_memberships
+  has_many :accounts, through: :account_memberships
   has_one :business, dependent: :destroy
   has_one :developer, dependent: :destroy
 

--- a/db/migrate/20220620170036_create_accounts.rb
+++ b/db/migrate/20220620170036_create_accounts.rb
@@ -1,0 +1,43 @@
+class CreateAccounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :accounts do |t|
+      t.belongs_to :profile, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    create_table :account_memberships do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+      t.belongs_to :account, null: false, foreign_key: true
+
+      t.string :role, default: "admin", index: true
+
+      t.timestamps
+    end
+
+    # TODO: Write a test to ensure the correct account is migrated.
+    [Business, Developer].each do |model|
+      model.in_batches do |batch|
+        account_attrs = batch.map do |business|
+          {
+            profile_id: business.id,
+            profile_type: model
+          }
+        end
+
+        accounts = Account.insert_all(
+          account_attrs, returning: %w[profile_id id]
+        ).rows.to_h
+
+        membership_attrs = batch.map do |business|
+          {
+            user_id: business.user_id,
+            account_id: accounts[business.id]
+          }
+        end
+
+        AccountMembership.insert_all(membership_attrs)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_10_205013) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_20_170036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "account_memberships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "account_id", null: false
+    t.string "role", default: "admin"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_account_memberships_on_account_id"
+    t.index ["role"], name: "index_account_memberships_on_role"
+    t.index ["user_id"], name: "index_account_memberships_on_user_id"
+  end
+
+  create_table "accounts", force: :cascade do |t|
+    t.string "profile_type", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_type", "profile_id"], name: "index_accounts_on_profile"
+  end
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
@@ -344,6 +363,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_10_205013) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "account_memberships", "accounts"
+  add_foreign_key "account_memberships", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "notification_tokens", "users"


### PR DESCRIPTION
This is the code from the the railsdevs episode of [Naming Things](https://www.namingthings.org/) with @joeldrapper.

The goal was to rework how `Business` vs. `Developer` is managed in the app. There is currently a lot of code required to know what "context" a user is in. We discovered that explicitly setting a context could be a great start.

The changes kick off the first steps towards having accounts and membership. To start, your current account will be your business account. If you don't have one then it will fall back to your developer account.

For most people they will never even see the idea of an account. But for the few who have both types of profiles a context switching UI will need to be added.

I like this approach because it means we can incrementally add on features of the accounts without having to worry about doing it all at once! Note that there are a few TODOs noted in 