### PR TITLE
Fix scroll to bottom on conversation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### June
 
+* June 30 - Fix scroll to bottom on conversation page - #521 @pkayokay
 * June 28 - Add plain text devise emails - #516 @jamgar
 * June 28 - Long-tail SEO pages for /developers #507
 * June 28 - Display X of Y developers in search results - #502

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### July
 
+* July 11 - Fix scroll to bottom and autofocus on conversation page - #521 @pkayokay
 * July 10 - Seed developer and business avatar images from Unsplash - #530 @adrienpoly
 * July 10 - Add privacy policy and terms & conditions
 * July 9 - In-app purchase support on iOS via RevenueCat
@@ -12,7 +13,6 @@
 
 ### June
 
-* June 30 - Fix scroll to bottom on conversation page - #521 @pkayokay
 * June 28 - Add plain text devise emails - #516 @jamgar
 * June 28 - Long-tail SEO pages for /developers #507
 * June 28 - Display X of Y developers in search results - #502

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -4,23 +4,29 @@ export default class extends Controller {
   static values = {
     onConnect: { type: Boolean, default: true },
     focus: { type: Boolean, default: true },
+    shouldScroll: { type: Boolean, default: true },
   }
 
   connect() {
     requestAnimationFrame(() => {
-      if (this.onConnectValue) this.scrollIntoView()
-      if (this.focusValue) this.focus()
+      if (this.shouldScrollValue) {
+        if (this.onConnectValue) this.scrollIntoView()
+        if (this.focusValue) this.focus()
+      }
+
+      // Persit scroll position when navigating backwards or forwards
+      window.onpopstate = (e) => {
+        this.shouldScrollValue = false
+      }
     })
   }
-
-  // actions
 
   scrollIntoView() {
     this.element.scrollIntoView(false)
   }
 
   focus() {
-    // focus on the first input , select or textarea in the element
+    // Focus on the first input , select or textarea in the element
     this.element.querySelector("input, select, textarea").focus()
   }
 }

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -2,8 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       this.element.scrollIntoView(false)
-    }, 0);
+    })
   }
 }

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -1,9 +1,26 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static values = {
+    onConnect: { type: Boolean, default: true },
+    focus: { type: Boolean, default: true },
+  }
+
   connect() {
     requestAnimationFrame(() => {
-      this.element.scrollIntoView(false)
+      if (this.onConnectValue) this.scrollIntoView()
+      if (this.focusValue) this.focus()
     })
+  }
+
+  // actions
+
+  scrollIntoView() {
+    this.element.scrollIntoView(false)
+  }
+
+  focus() {
+    // focus on the first input , select or textarea in the element
+    this.element.querySelector("input, select, textarea").focus()
   }
 }

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -10,8 +10,13 @@ export default class extends Controller {
   connect() {
     requestAnimationFrame(() => {
       if (this.shouldScrollValue) {
-        if (this.onConnectValue) this.scrollIntoView()
-        if (this.focusValue) this.focus()
+        if (this.onConnectValue) {
+          this._scrollIntoView()
+        }
+
+        if (this.focusValue) {
+          this._focus()
+        }
       }
 
       // Persit scroll position when navigating backwards or forwards
@@ -21,11 +26,11 @@ export default class extends Controller {
     })
   }
 
-  scrollIntoView() {
+  _scrollIntoView() {
     this.element.scrollIntoView(false)
   }
 
-  focus() {
+  _focus() {
     // Focus on the first input , select or textarea in the element
     this.element.querySelector("input, select, textarea").focus()
   }

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -2,14 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    document.addEventListener("turbo:load", this.scrollIntoView)
-  }
-
-  disconnect() {
-    document.removeEventListener("turbo:load", this.scrollIntoView)
-  }
-
-  scrollIntoView() {
     this.element.scrollIntoView(false)
   }
 }

--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    this.element.scrollIntoView(false)
+    setTimeout(() => {
+      this.element.scrollIntoView(false)
+    }, 0);
   }
 }


### PR DESCRIPTION
This PR fixes scrolling to the bottom on the individual conversation page (the TypeError)
https://github.com/joemasilotti/railsdevs.com/issues/511

It was not actually "scrolling" but autofocusing on the `text_area` field. This essentially scrolls most of the time but it doesn't ensure that the text area is fully visible all the time.

Note: It is expected that scrolling to the bottom does not happen when going back or forward to the conversation page.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
