### PR TITLE
Demo accounts for App Store review

### DIFF
--- a/app/components/businesses/upgrade_required_component.html.erb
+++ b/app/components/businesses/upgrade_required_component.html.erb
@@ -8,16 +8,18 @@
       <div class="mt-2 text-sm text-red-700">
         <p><%= body %></p>
       </div>
-      <div class="mt-4">
-        <div class="-mx-2 -my-1.5 flex">
-          <% if expired? %>
-            <%= link_to cta, pricing_path, class: "bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
-          <% else %>
-            <%= link_to cta, stripe_portal_path, class: "bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
-            <%= link_to t(".details"), pricing_path, class: "ml-3 bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
-          <% end %>
+      <% unless demo? %>
+        <div class="mt-4">
+          <div class="-mx-2 -my-1.5 flex">
+            <% if expired? %>
+              <%= link_to cta, pricing_path, class: "bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
+            <% else %>
+              <%= link_to cta, stripe_portal_path, class: "bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
+              <%= link_to t(".details"), pricing_path, class: "ml-3 bg-red-50 px-2 py-1.5 rounded-md text-sm font-medium text-red-800 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-50 focus:ring-red-600" %>
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/components/businesses/upgrade_required_component.rb
+++ b/app/components/businesses/upgrade_required_component.rb
@@ -14,9 +14,15 @@ module Businesses
       !permission.active_subscription?
     end
 
+    def demo?
+      permission.demo_subscription?
+    end
+
     def title
       if expired?
         t(".title.expired")
+      elsif demo?
+        t(".title.demo")
       else
         t(".title.upgrade")
       end
@@ -25,6 +31,8 @@ module Businesses
     def body
       if expired?
         t(".body.expired")
+      elsif demo?
+        t(".body.demo")
       else
         t(".body.upgrade")
       end

--- a/app/models/businesses/permission.rb
+++ b/app/models/businesses/permission.rb
@@ -14,6 +14,10 @@ module Businesses
       active_subscriptions(:legacy).any?
     end
 
+    def demo_subscription?
+      active_subscriptions(:demo).any?
+    end
+
     def pays_hiring_fee?
       full_time_subscription?
     end
@@ -24,7 +28,7 @@ module Businesses
       elsif part_time_subscription? && !developer.role_type.only_full_time_employment?
         true
       else
-        false
+        demo_subscription? && developer.demo?
       end
     end
 

--- a/app/models/businesses/permission.rb
+++ b/app/models/businesses/permission.rb
@@ -18,10 +18,10 @@ module Businesses
       full_time_subscription?
     end
 
-    def can_message_developer?(role_type:)
+    def can_message_developer?(developer)
       if legacy_subscription? || full_time_subscription? || free_subscription?
         true
-      elsif part_time_subscription? && !role_type.only_full_time_employment?
+      elsif part_time_subscription? && !developer.role_type.only_full_time_employment?
         true
       else
         false

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -5,7 +5,7 @@ class MessagePolicy < ApplicationPolicy
     elsif developer_sender?
       true
     elsif business_sender?
-      permission.can_message_developer?(role_type: developer.role_type)
+      permission.can_message_developer?(developer)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
       title: Requires an active business subscription.
     upgrade_required_component:
       body:
+        demo: This demo account can only message demo developers.
         expired: Your subscription has expired. Reactivate your account to continue messaging developers.
         upgrade: With your current plan you can only message developers looking for part-time work. Upgrade your account to message this developer.
       cta:
@@ -173,6 +174,7 @@ en:
         upgrade: Upgrade my account
       details: View pricing details
       title:
+        demo: Demo account
         expired: Subscription expired
         upgrade: Upgrade required
   cold_messages:

--- a/config/plans.yml
+++ b/config/plans.yml
@@ -19,3 +19,8 @@ shared:
     price: 0
     stripe_price_id: free
     revenue_cat_product_identifier: free
+  demo:
+    name: Demo
+    price: 0
+    stripe_price_id: demo
+    revenue_cat_product_identifier: demo

--- a/db/migrate/20220710014404_add_demo_to_developers.rb
+++ b/db/migrate/20220710014404_add_demo_to_developers.rb
@@ -1,0 +1,5 @@
+class AddDemoToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :demo, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_214631) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_10_014404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,6 +107,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_214631) do
     t.virtual "textsearchable_index_col", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((COALESCE(hero, ''::character varying))::text || ' '::text) || COALESCE(bio, ''::text)))", stored: true
     t.datetime "featured_at"
     t.boolean "profile_reminder_notifications", default: true
+    t.boolean "demo", default: false, null: false
     t.index ["textsearchable_index_col"], name: "textsearchable_index", using: :gin
     t.index ["user_id"], name: "index_developers_on_user_id"
   end

--- a/db/seeds/businesses.rb
+++ b/db/seeds/businesses.rb
@@ -8,6 +8,10 @@ SeedsHelper.subscribe_user_to_plan(business.user, plan_identifier: :full_time)
 business = SeedsHelper.create_business!("part-time")
 SeedsHelper.subscribe_user_to_plan(business.user, plan_identifier: :part_time)
 
+# Business on demo plan (for App Store review)
+business = SeedsHelper.create_business!("demo-business")
+SeedsHelper.subscribe_user_to_plan(business.user, plan_identifier: :demo)
+
 # Lead business (lead)
 SeedsHelper.create_business!("lead")
 

--- a/db/seeds/businesses.rb
+++ b/db/seeds/businesses.rb
@@ -2,19 +2,11 @@
 business = SeedsHelper.create_business!("business", {
   developer_notifications: :daily
 })
-if business.user.subscriptions.none?
-  business.user.set_payment_processor(:fake_processor, allow_fake: true)
-  business.user.payment_processor
-    .subscribe(plan: Businesses::Plan.with_identifier(:full_time).stripe_price_id)
-end
+SeedsHelper.subscribe_user_to_plan(business.user, plan_identifier: :full_time)
 
 # Business on part-time plan (part-time)
 business = SeedsHelper.create_business!("part-time")
-if business.user.subscriptions.none?
-  business.user.set_payment_processor(:fake_processor, allow_fake: true)
-  business.user.payment_processor
-    .subscribe(plan: Businesses::Plan.with_identifier(:part_time).stripe_price_id)
-end
+SeedsHelper.subscribe_user_to_plan(business.user, plan_identifier: :part_time)
 
 # Lead business (lead)
 SeedsHelper.create_business!("lead")

--- a/db/seeds/developers.rb
+++ b/db/seeds/developers.rb
@@ -79,3 +79,10 @@ developer = SeedsHelper.create_developer!("hired", {
   role_level: RoleLevel.new(RoleLevel::TYPES.map { |t| [t, true] }.to_h)
 })
 developer.update!(search_status: :not_interested) unless developer.not_interested?
+
+# Demo developer
+SeedsHelper.create_developer!("demo-developer", {
+  hero: "Demo developer",
+  location: SeedsHelper.locations[:new_york],
+  demo: true
+})

--- a/lib/seeds_helper.rb
+++ b/lib/seeds_helper.rb
@@ -38,6 +38,14 @@ module SeedsHelper
       end
     end
 
+    def subscribe_user_to_plan(user, plan_identifier:)
+      if user.subscriptions.none?
+        plan = Businesses::Plan.with_identifier(plan_identifier)
+        user.set_payment_processor(:fake_processor, allow_fake: true)
+        user.payment_processor.subscribe(plan: plan.stripe_price_id)
+      end
+    end
+
     def locations
       location_seeds.map do |name, attrs|
         [name.to_sym, Location.new(attrs)]

--- a/lib/seeds_helper.rb
+++ b/lib/seeds_helper.rb
@@ -52,6 +52,13 @@ module SeedsHelper
       end.to_h
     end
 
+    def attach_avatar(record, name:)
+      url = "https://ui-avatars.com/api/?size=300&background=random&name=#{name.parameterize}"
+      uri = URI.parse(url)
+      file = uri.open
+      record.avatar.attach(io: file, filename: "avatar.png")
+    end
+
     private
 
     def create_user!(name)
@@ -66,13 +73,6 @@ module SeedsHelper
       User.find_or_create_by!(email:) do |user|
         user.assign_attributes(attributes)
       end
-    end
-
-    def attach_avatar(record, name:)
-      url = "https://ui-avatars.com/api/?size=300&background=random&name=#{name.parameterize}"
-      uri = URI.parse(url)
-      file = uri.open
-      record.avatar.attach(io: file, filename: "avatar.png")
     end
 
     def location_seeds

--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -1,10 +1,51 @@
+require "seeds_helper"
+
 desc "These tasks are meant to be run once then removed"
 namespace :backfills do
-  desc "Generate avatar variants for developers and businesses"
-  task process_avatar_variants: :environment do
-    ActiveStorage::Attachment.where(name: "avatar").find_each do |attachment|
-      attachment.variant(:thumb).processed
-      attachment.variant(:medium).processed
+  desc "Create and confirm two demo accounts for App Store review"
+  task demo_accounts: :environment do
+    User.transaction do
+      # Create demo developer.
+      developer_password = SecureRandom.hex(10)
+      user = User.create!(
+        email: "demo-developer@example.com",
+        password: developer_password,
+        confirmed_at: Time.current
+      )
+      developer = Developer.new(
+        user:,
+        demo: true,
+        hero: "Demo Developer",
+        name: "Demo Developer",
+        bio: "Don't message me, I'm a demo account for App Store review!",
+        location: SeedsHelper.locations[:new_york]
+      )
+      SeedsHelper.attach_avatar(developer, name: "Demo Developer")
+      developer.save!
+
+      # Create demo business.
+      business_password = SecureRandom.hex(10)
+      user = User.create!(
+        email: "demo-business@example.com",
+        password: business_password,
+        confirmed_at: Time.current
+      )
+      business = Business.new(
+        user:,
+        name: "Demo Business",
+        company: "Demo Business",
+        bio: "I won't message you, I'm a demo account for App Store review!"
+      )
+      SeedsHelper.attach_avatar(business, name: "Demo Business")
+      business.save!
+
+      plan = Businesses::Plan.with_identifier(:demo)
+      business.user.set_payment_processor(:fake_processor, allow_fake: true)
+      business.user.payment_processor.subscribe(plan: plan.stripe_price_id)
+
+      # Print passwords to share with App Store review team.
+      puts "Developer password: #{developer_password}"
+      puts "Business password: #{business_password}"
     end
   end
 end

--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -18,6 +18,7 @@ namespace :backfills do
         hero: "Demo Developer",
         name: "Demo Developer",
         bio: "Don't message me, I'm a demo account for App Store review!",
+        search_status: :invisible,
         location: SeedsHelper.locations[:new_york]
       )
       SeedsHelper.attach_avatar(developer, name: "Demo Developer")

--- a/test/components/businesses/upgrade_required_component_test.rb
+++ b/test/components/businesses/upgrade_required_component_test.rb
@@ -33,5 +33,16 @@ module Businesses
       assert_text I18n.t("businesses.upgrade_required_component.cta.upgrade")
       assert_selector "a[href='/stripe/portal']"
     end
+
+    test "demo accounts don't see a CTA" do
+      user = users(:subscribed_business)
+      update_subscription(:demo)
+
+      render_inline UpgradeRequiredComponent.new(user)
+
+      assert_text I18n.t("businesses.upgrade_required_component.title.demo")
+      assert_text I18n.t("businesses.upgrade_required_component.body.demo")
+      assert_no_selector "a"
+    end
   end
 end

--- a/test/models/businesses/permission_test.rb
+++ b/test/models/businesses/permission_test.rb
@@ -69,6 +69,18 @@ class Businesses::PermissionTest < ActiveSupport::TestCase
     refute permission.can_message_developer?(flexible_developer)
   end
 
+  test "demo subscriptions can only message demo developers" do
+    customer = pay_customers(:one)
+    update_subscription(:demo)
+
+    permission = Businesses::Permission.new(customer.subscriptions)
+
+    refute permission.can_message_developer?(part_time_developer)
+    refute permission.can_message_developer?(full_time_developer)
+    refute permission.can_message_developer?(flexible_developer)
+    assert permission.can_message_developer?(demo_developer)
+  end
+
   test "no subscriptions doesn't raise" do
     permission = Businesses::Permission.new(nil)
 
@@ -91,5 +103,9 @@ class Businesses::PermissionTest < ActiveSupport::TestCase
       part_time_contract: true,
       full_time_employment: true
     })
+  end
+
+  def demo_developer
+    Developer.new(demo: true)
   end
 end

--- a/test/models/businesses/permission_test.rb
+++ b/test/models/businesses/permission_test.rb
@@ -37,36 +37,36 @@ class Businesses::PermissionTest < ActiveSupport::TestCase
     customer = pay_customers(:one)
     update_subscription(:part_time)
     permission = Businesses::Permission.new(customer.subscriptions)
-    assert permission.can_message_developer?(role_type: part_time_role_type)
-    refute permission.can_message_developer?(role_type: full_time_role_type)
-    assert permission.can_message_developer?(role_type: flexible_role_type)
+    assert permission.can_message_developer?(part_time_developer)
+    refute permission.can_message_developer?(full_time_developer)
+    assert permission.can_message_developer?(flexible_developer)
   end
 
   test "full-time, legacy, and free subscriptions can message any developer" do
     customer = pay_customers(:one)
     permission = Businesses::Permission.new(customer.subscriptions)
-    assert permission.can_message_developer?(role_type: part_time_role_type)
-    assert permission.can_message_developer?(role_type: full_time_role_type)
-    assert permission.can_message_developer?(role_type: flexible_role_type)
+    assert permission.can_message_developer?(part_time_developer)
+    assert permission.can_message_developer?(full_time_developer)
+    assert permission.can_message_developer?(flexible_developer)
 
     update_subscription(:legacy)
     permission = Businesses::Permission.new(customer.subscriptions)
-    assert permission.can_message_developer?(role_type: part_time_role_type)
-    assert permission.can_message_developer?(role_type: full_time_role_type)
-    assert permission.can_message_developer?(role_type: flexible_role_type)
+    assert permission.can_message_developer?(part_time_developer)
+    assert permission.can_message_developer?(full_time_developer)
+    assert permission.can_message_developer?(flexible_developer)
 
     update_subscription(:free)
     permission = Businesses::Permission.new(customer.subscriptions)
-    assert permission.can_message_developer?(role_type: part_time_role_type)
-    assert permission.can_message_developer?(role_type: full_time_role_type)
-    assert permission.can_message_developer?(role_type: flexible_role_type)
+    assert permission.can_message_developer?(part_time_developer)
+    assert permission.can_message_developer?(full_time_developer)
+    assert permission.can_message_developer?(flexible_developer)
   end
 
   test "inactive subscriptions can't message anyone" do
     permission = Businesses::Permission.new(Pay::Subscription.none)
-    refute permission.can_message_developer?(role_type: part_time_role_type)
-    refute permission.can_message_developer?(role_type: full_time_role_type)
-    refute permission.can_message_developer?(role_type: flexible_role_type)
+    refute permission.can_message_developer?(part_time_developer)
+    refute permission.can_message_developer?(full_time_developer)
+    refute permission.can_message_developer?(flexible_developer)
   end
 
   test "no subscriptions doesn't raise" do
@@ -78,15 +78,18 @@ class Businesses::PermissionTest < ActiveSupport::TestCase
     refute permission.can_message_developer?(role_type: nil)
   end
 
-  def part_time_role_type
-    RoleType.new(part_time_contract: true)
+  def part_time_developer
+    Developer.new(role_type_attributes: {part_time_contract: true})
   end
 
-  def full_time_role_type
-    RoleType.new(full_time_employment: true)
+  def full_time_developer
+    Developer.new(role_type_attributes: {full_time_employment: true})
   end
 
-  def flexible_role_type
-    RoleType.new(part_time_contract: true, full_time_employment: true)
+  def flexible_developer
+    Developer.new(role_type_attributes: {
+      part_time_contract: true,
+      full_time_employment: true
+    })
   end
 end

--- a/test/models/businesses/plan_test.rb
+++ b/test/models/businesses/plan_test.rb
@@ -10,7 +10,7 @@ class Businesses::PlanTest < ActiveSupport::TestCase
   end
 
   test "finds all plans" do
-    identifiers = %w[free legacy part_time full_time]
+    identifiers = %w[legacy part_time full_time free demo]
 
     identifiers.each do |identifier|
       assert_not_nil Businesses::Plan.with_identifier(identifier)


### PR DESCRIPTION
This PR adds the scaffolding and development database seeds for demo accounts. App Store review mentioned needing them (along with other things) but I forgot to add them before resubmitting. (Whoops!)

This PR will only be merged if the submission is rejected again. I don't _want_ any of this code in the app.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

## Deployment checklist

- [ ] Merge and deploy this PR
- [ ] Run `heroku run bundle exec rake backfills:demo_accounts -a rails-devs`
- [ ] Create a PR that removes the new backfill task (and the `require` at the top)