### PR TITLE
Add 1x and 2x avatar image variant

### DIFF
--- a/app/components/avatar_component.html.erb
+++ b/app/components/avatar_component.html.erb
@@ -1,1 +1,5 @@
-<%= image_tag image, alt: "#{name} avatar", data: data, class: "#{classes} object-cover bg-gray-300 rounded-full" %>
+<%= image_tag image,
+      srcset: {"#{url_for image_2x}": "2x"},
+      alt: "#{name} avatar",
+      data: data,
+      class: "#{classes} object-cover bg-gray-300 rounded-full" %>

--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -15,6 +15,11 @@ class AvatarComponent < ViewComponent::Base
     variant ? avatarable.avatar.variant(variant) : avatarable.avatar
   end
 
+  def image_2x
+    return DEFAULT_AVATAR unless avatarable&.avatar&.attached?
+    variant ? avatarable.avatar.variant("#{variant}_2x".to_sym) : avatarable.avatar
+  end
+
   def classes
     @classes || "h-24 w-24 sm:h-32 sm:w-32 ring-4 ring-white"
   end

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -3,8 +3,10 @@ module Avatarable
 
   included do
     has_one_attached :avatar do |attachable|
-      attachable.variant :thumb, resize_to_limit: [64, 64]
-      attachable.variant :medium, resize_to_limit: [256, 256]
+      attachable.variant :thumb, resize_to_limit: [32, 32]
+      attachable.variant :thumb_2x, resize_to_limit: [64, 64]
+      attachable.variant :medium, resize_to_limit: [128, 128]
+      attachable.variant :medium_2x, resize_to_limit: [256, 256]
     end
 
     validates :avatar, content_type: ["image/png", "image/jpeg", "image/jpg"],

--- a/lib/tasks/backfills.rake
+++ b/lib/tasks/backfills.rake
@@ -4,7 +4,9 @@ namespace :backfills do
   task process_avatar_variants: :environment do
     ActiveStorage::Attachment.where(name: "avatar").find_each do |attachment|
       attachment.variant(:thumb).processed
+      attachment.variant(:thumb_2x).processed
       attachment.variant(:medium).processed
+      attachment.variant(:medium_2x).processed
     end
   end
 end

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class AvatarComponentTest < ViewComponent::TestCase
   include ActionView::Helpers::AssetUrlHelper
+  include ActionView::Helpers::UrlHelper
+  include Rails.application.routes.url_helpers
 
   setup do
     @developer = developers(:one)
@@ -19,7 +21,15 @@ class AvatarComponentTest < ViewComponent::TestCase
     render_inline(avatar_component)
 
     assert_instance_of ActiveStorage::VariantWithRecord, avatar_component.image
-    assert_equal [64, 64], avatar_component.image.variation.transformations[:resize_to_limit]
+    assert_equal [32, 32], avatar_component.image.variation.transformations[:resize_to_limit]
+    assert_equal [64, 64], avatar_component.image_2x.variation.transformations[:resize_to_limit]
+  end
+
+  test "should render srcset for 2x images" do
+    avatar_component = AvatarComponent.new(avatarable: @developer, variant: :thumb)
+    render_inline(avatar_component)
+
+    assert_selector("img[srcset$='#{url_for @developer.avatar.variant(:thumb_2x)} 2x']")
   end
 
   test "should fall back to default" do


### PR DESCRIPTION
close #519

This PR enhance the AvatarComponent to provide both 1x and 2x images. This is a performance improvement, standard monitor will receive the 1x image (32x32) for thumbnail. Whereas Retina monitors will receive the 64x64. Everything is handled by the standard `srcset` html attribute.

I added 2 new variants in the `Avatarable` concern `thumb_2x` and `medium_2x`. From my test locale with a db having only the previous variant, Rails generate automatically the new ones on the first request.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
