### PR TITLE
Fix JS warning : add missing bind(this)

### DIFF
--- a/app/javascript/controllers/page_scroll_controller.js
+++ b/app/javascript/controllers/page_scroll_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    document.addEventListener("turbo:load", this.scrollIntoView)
+    document.addEventListener("turbo:load", this.scrollIntoView.bind(this))
   }
 
   disconnect() {


### PR DESCRIPTION
In the message view there is a console js warning poping up

![Capture d’écran 2022-07-10 à 11 21 22 PM](https://user-images.githubusercontent.com/7847244/178162628-05a70b87-367e-4d63-b21d-97edd38c26d6.jpg)

This PR adds the mising bind(this) to the `eventListener` declaration so that this is defined insisde the `scrollIntoView` method.


> **Note**
This being said I am not sure this Stimulus controller is realy doing what it is meant to do. On page load it will `scrollIntoView` this is I think the expected behavior. But when typing new message the form will disapear from the Viewport. Isn't the expected behavior to keep the form visible after a new message has been posted ?

![Capture d’écran 2022-07-10 à 11 33 10 PM](https://user-images.githubusercontent.com/7847244/178162787-487d4785-b422-4915-bcb6-2a19c92674a3.jpg)



## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
