### PR TITLE
Fix Tarpon initializer that's throwing a NoMethodError

### DIFF
--- a/config/initializers/tarpon.rb
+++ b/config/initializers/tarpon.rb
@@ -1,5 +1,5 @@
 Tarpon::Client.configure do |c|
-  c.public_api_key = Rails.application.credentials.revenue_cat.public_key
-  c.secret_api_key = Rails.application.credentials.revenue_cat.private_key
+  c.public_api_key = Rails.application.credentials.dig(:revenue_cat, :public_key)
+  c.secret_api_key = Rails.application.credentials.dig(:revenue_cat, :private_key)
   c.timeout = 5
 end


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->
Hello. I was setting up the app locally and ran into a `NoMethodError` the tarpon intializer was throwing because I don't have the credentials.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
