### PR TITLE
Toggle 'Sort' button's aria-expanded attribute value.

### DIFF
--- a/app/components/developers/query_sort_button_component.html.erb
+++ b/app/components/developers/query_sort_button_component.html.erb
@@ -1,5 +1,5 @@
-<div data-controller="toggle" data-toggle-visibility-class="hidden" id="sort" class="relative">
-  <button type="button" class="group inline-flex justify-center text-sm font-medium text-gray-700 hover:text-gray-900" data-action="toggle#toggle" aria-expanded="false" aria-haspopup="true">
+<div data-controller="toggle accessibility" data-toggle-visibility-class="hidden" id="sort" class="relative">
+  <button data-accessibility-target="button" type="button" class="group inline-flex justify-center text-sm font-medium text-gray-700 hover:text-gray-900" data-action="toggle#toggle accessibility#toggleAriaExpanded" aria-expanded="false" aria-haspopup="true">
     <%= t(".sort.title") %>
     <%= inline_svg_tag "icons/solid/chevron_down.svg", class: "flex-shrink-0 -mr-1 ml-1 h-5 w-5 text-gray-400 group-hover:text-gray-500" %>
   </button>

--- a/app/javascript/controllers/accessibility_controller.js
+++ b/app/javascript/controllers/accessibility_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button"]
+
+  toggleAriaExpanded() {
+    const element = this.buttonTarget;
+    const initialVal = element.getAttribute("aria-expanded")
+    const toggledVal = initialVal === "true" ? "false" : "true"
+
+    element.setAttribute("aria-expanded", toggledVal)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,9 @@
 
 import { application } from "./application"
 
+import AccessibilityController from "./accessibility_controller.js"
+application.register("accessibility", AccessibilityController)
+
 import Analytics__EventsController from "./analytics/events_controller.js"
 application.register("analytics--events", Analytics__EventsController)
 


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->

This should address issue #539.

Small background regarding the thinking for this implementation:

We add a Stimulus.js `AccessibilityController` where we define actions that handle the updating of values of accessibility related attributes, e.g. in this case it is `#toggleAriaExpanded` to handle "aria-expanded", while in the future it might be a case where we add `#toggleAriaChecked` for handling the "aria-checked" attribute.

I briefly wondered: should there be an integration test covering this?

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
