### PR TITLE
Add and toggle aria-expanded attribute value for collapse control button

### DIFF
--- a/app/components/collapse_control_component.html.erb
+++ b/app/components/collapse_control_component.html.erb
@@ -1,4 +1,4 @@
-<button type="button" class="px-2 py-3 w-full flex items-center justify-between text-gray-400 hover:text-gray-500 text-sm" data-action="toggle#toggle">
+<button type="button" class="px-2 py-3 w-full flex items-center justify-between text-gray-400 hover:text-gray-500 text-sm" data-action="toggle#toggle accessibility#toggleAriaExpanded" aria-expanded="<%= !collapsed? %>" data-accessibility-target="button">
   <%= tag.span title, class: title_class %>
   <span class="ml-6 flex items-center">
     <%= inline_svg_tag "icons/solid/minus_sm.svg", class: minus_icon_class, data: {"toggle-target": "element"} %>

--- a/app/components/developers/query_component.html.erb
+++ b/app/components/developers/query_component.html.erb
@@ -11,7 +11,7 @@
       <% end %>
     </div>
 
-    <div data-controller="toggle" data-toggle-visibility-class="hidden">
+    <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
       <div class="border-t border-gray-200 py-6">
         <h3 class="-mx-2 -my-3 flow-root">
           <%= render CollapseControlComponent.new(t(".role_level.title")) %>
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <div data-controller="toggle" data-toggle-visibility-class="hidden">
+    <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
       <div class="border-t border-gray-200 py-6">
         <h3 class="-mx-2 -my-3 flow-root">
           <%= render CollapseControlComponent.new(t(".work_preference.title")) %>
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-    <div data-controller="toggle" data-toggle-visibility-class="hidden">
+    <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
       <div class="border-t border-gray-200 py-6">
         <h3 class="-mx-2 -my-3 flow-root">
           <%= render CollapseControlComponent.new(t(".country.title"), collapsed: true) %>
@@ -69,7 +69,7 @@
             <% end %>
           </div>
 
-          <div data-controller="toggle" data-toggle-visibility-class="hidden">
+          <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
             <div class="pt-6">
               <h5 class="-mx-2 -my-3 flow-root">
                 <%= render CollapseControlComponent.new(t(".all_countries.title"), collapsed: true, subcomponent: true) %>
@@ -90,7 +90,7 @@
       </div>
     </div>
 
-    <div data-controller="toggle" data-toggle-visibility-class="hidden">
+    <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
       <div class="border-t border-gray-200 py-6">
         <h3 class="-mx-2 -my-3 flow-root">
           <%= render CollapseControlComponent.new(t(".timezone.title"), collapsed: true) %>


### PR DESCRIPTION
This pull request resolves the screen reader accessibility problem for expandable menus in [developers page](https://railsdevs.com/developers) as mentioned in the issue [#553](https://github.com/joemasilotti/railsdevs.com/issues/553).

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
