### PR TITLE
WIP: Reasons for invisibilizing developers

### DIFF
--- a/.erblint-rubocop20220803-82502-7594it
+++ b/.erblint-rubocop20220803-82502-7594it
@@ -1,0 +1,8 @@
+---
+require: standard
+inherit_gem:
+  standard: config/base.yml
+Layout/InitialIndentation:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false

--- a/app/components/developers/admin_component.html.erb
+++ b/app/components/developers/admin_component.html.erb
@@ -9,7 +9,7 @@
     </button>
   <% end %>
 
-  <%= button_to admin_developer_invisiblizes_path(developer), method: :post, rel: "nofollow", class: "-ml-px relative inline-flex items-center px-3 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500", form: {data: {turbo_confirm: "Mark this developer as invisible and notify them via email?"}} do %>
+  <%= link_to new_admin_developer_invisiblize_path(developer), data: {"turbo-frame": "modal"}, class: "-ml-px relative inline-flex items-center px-3 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500" do %>
     <%= inline_svg_tag "icons/solid/eye_off.svg", class: "-ml-1 mr-2 h-5 w-5 text-gray-400" %>
     <%= t(".invisiblize") %>
   <% end %>

--- a/app/controllers/admin/developers/invisiblizes_controller.rb
+++ b/app/controllers/admin/developers/invisiblizes_controller.rb
@@ -1,8 +1,13 @@
 module Admin
   module Developers
     class InvisiblizesController < ApplicationController
+      def new
+        @developer = Developer.find(params[:developer_id])
+      end
+
       def create
-        Developer.find(params[:developer_id]).invisiblize_and_notify!
+        developer = Developer.find(params[:developer_id])
+        developer.invisiblize_and_notify!(params[:reason])
         redirect_to developers_path, notice: t(".created")
       end
     end

--- a/app/models/concerns/developers/notifications.rb
+++ b/app/models/concerns/developers/notifications.rb
@@ -15,9 +15,9 @@ module Developers
       end
     end
 
-    def invisiblize_and_notify!
+    def invisiblize_and_notify!(reason)
       invisible!
-      send_invisiblize_notification
+      send_invisiblize_notification(reason)
     end
 
     def notify_as_stale
@@ -52,8 +52,13 @@ module Developers
       Admin::PotentialHireNotification.with(developer: self).deliver_later(User.admin)
     end
 
-    def send_invisiblize_notification
-      InvisiblizeNotification.with(developer: self).deliver_later(user)
+    def send_invisiblize_notification(reason)
+      reason = InvisibleProfile.with_reason(reason)
+      InvisiblizeNotification.with(
+        developer: self,
+        message: reason.message,
+        next_steps: reason.next_steps
+      ).deliver_later(user)
     end
   end
 end

--- a/app/models/invisible_profile.rb
+++ b/app/models/invisible_profile.rb
@@ -1,0 +1,43 @@
+class InvisibleProfile
+  class UnknownReason < StandardError; end
+
+  REASONS = %i[incomplete not_responding]
+
+  attr_reader :reason
+
+  def self.all
+    REASONS.map { |r| with_reason(r) }
+  end
+
+  def self.with_reason(reason)
+    unless REASONS.include?(reason.to_s.to_sym)
+      raise UnknownReason.new("Unknown reason: '#{reason}'.")
+    end
+
+    new(reason)
+  end
+
+  def help_text
+    # i18n-tasks-use t("invisible_profile.incomplete.help_text"))
+    # i18n-tasks-use t("invisible_profile.not_responding.help_text"))
+    I18n.t(:help_text, scope: [:invisible_profile, reason])
+  end
+
+  def message
+    # i18n-tasks-use t("invisible_profile.incomplete.message"))
+    # i18n-tasks-use t("invisible_profile.not_responding.message"))
+    I18n.t(:message, scope: [:invisible_profile, reason])
+  end
+
+  def next_steps
+    # i18n-tasks-use t("invisible_profile.incomplete.next_steps"))
+    # i18n-tasks-use t("invisible_profile.not_responding.next_steps"))
+    I18n.t(:next_steps, scope: [:invisible_profile, reason])
+  end
+
+  private
+
+  def initialize(reason)
+    @reason = reason
+  end
+end

--- a/app/notifications/developers/invisiblize_notification.rb
+++ b/app/notifications/developers/invisiblize_notification.rb
@@ -3,7 +3,7 @@ module Developers
     deliver_by :database
     deliver_by :email, mailer: "InvisiblizeMailer", method: :to_developer
 
-    param :developer
+    param :developer, :message, :next_steps
 
     def title
       t("notifications.developers.invisiblize_notification.title")
@@ -15,6 +15,14 @@ module Developers
 
     def developer
       params[:developer]
+    end
+
+    def message
+      params[:message]
+    end
+
+    def next_steps
+      params[:next_steps]
     end
   end
 end

--- a/app/views/admin/developers/invisiblizes/new.html.erb
+++ b/app/views/admin/developers/invisiblizes/new.html.erb
@@ -1,0 +1,54 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <%= form_with url: admin_developer_invisiblizes_path(@developer), data: {turbo_frame: "_top"}, class: "inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6" do |form| %>
+        <div class="sm:flex sm:items-start">
+          <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
+            <%= inline_svg_tag "icons/outline/exclamation.svg", class: "h-6 w-6 text-gray-600" %>
+          </div>
+          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+            <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+              <%= t(".title") %>
+            </h3>
+            <div class="mt-2">
+              <p class="text-sm text-gray-500"><%= t(".message") %></p>
+            </div>
+
+            <div class="mt-8">
+              <div class="space-y-6">
+                <fieldset>
+                  <legend class="text-sm font-medium text-gray-500">
+                    Reason for invisiblizing:
+                  </legend>
+
+                  <div class="mt-4 space-y-4">
+                    <% InvisibleProfile.all.each_with_index do |reason, index| %>
+                      <div class="flex items-start">
+                        <div class="h-5 flex items-center">
+                          <%= form.radio_button :reason, reason.reason, checked: index == 0, class: "focus:ring-gray-500 h-4 w-4 text-gray-600 border-gray-300" %>
+                        </div>
+                        <div class="ml-3 text-sm">
+                          <%= form.label :reason, reason.help_text, value: reason.reason, class: "font-medium text-gray-700" %>
+                        </div>
+                      </div>
+                    <% end %>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+          <%= button_tag t(".invisiblize"), type: :submit, class: "w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-gray-600 text-base font-medium text-white hover:bg-gray-700 hover:cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:ml-3 sm:w-auto sm:text-sm" %>
+          <%= link_to t(".cancel"), developer_path(@developer), class: "mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:mt-0 sm:w-auto sm:text-sm" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/invisiblize_mailer/to_developer.html.erb
+++ b/app/views/invisiblize_mailer/to_developer.html.erb
@@ -1,4 +1,5 @@
 <p>Hey <%= @developer.first_name %>,</p>
-<p>I'm Joe, the founder of <%= link_to "railsdevs", root_url %>. <%= link_to "Your developer profile", notification_url(@notification.record) %> was flagged because it doesn't contain enough information and kind of looks like spam.</p>
-<p>I've set your profile to invisible – only you can see it. You can toggle this back to visible after you add more details to your profile.</p>
+<p>I'm Joe, the founder of <%= link_to "railsdevs", root_url %>.</p>
+<%= link_to "Your developer profile", notification_url(@notification.record) %> was flagged because <%= @notification.message %>.</p>
+<p>I've marked it as invisible – only you can see it. You can toggle this back to visible when <%= @notification.next_steps %>.</p>
 <%= render "shared/signature" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,14 @@
 ---
 en:
+  invisible_profile:
+    incomplete:
+      help_text: Profile too short
+      message: it doesn't contain a lot of information (and kind of looks like spam)
+      next_steps: you add more details to your profile
+    not_responding:
+      help_text: Not responding to messages
+      message: you haven't been responding to messages from businesses
+      next_steps: you are ready to start replying
   about:
     show:
       caption_html: founder of <code class="text-gray-900 font-semibold">railsdevs</code>
@@ -88,6 +97,11 @@ en:
       invisiblizes:
         create:
           created: Profile set to invisible.
+        new:
+          invisiblize: Invisiblize
+          cancel: Cancel
+          message: Mark this developer as invisible and notify them via email?
+          title: Invisiblize developer
     features:
       create:
         created: Profile featured for one week.
@@ -410,7 +424,7 @@ en:
         title: Your profile on railsdevs was flagged
     developers:
       invisiblize_notification:
-        title: Your profile on railsdevs was flagged
+        title: Your profile on railsdevs is no longer visible
       profile_reminder_notification:
         email_subject: Is your railsdevs profile up to date?
         title: Is your developer profile up to date?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,7 +64,7 @@ Rails.application.routes.draw do
     resources :developers, only: [] do
       resources :conversations, only: :index, controller: :developer_conversations
       resources :features, only: :create
-      resources :invisiblizes, only: :create, module: :developers
+      resources :invisiblizes, only: [:new, :create], module: :developers
     end
   end
 

--- a/db/seeds/notifications.rb
+++ b/db/seeds/notifications.rb
@@ -16,7 +16,12 @@ Notification.find_or_create_by!(type: Developers::ProfileReminderNotification.na
 
 # InvisiblizeMailer#to_developer
 invisible_developer = User.find_by(email: "invisible@example.com").developer
-Notification.find_or_create_by!(type: Developers::InvisiblizeNotification.name, recipient: invisible_developer.user, params: {developer: invisible_developer})
+reason = InvisibleProfile.with_reason(:incomplete)
+Notification.find_or_create_by!(type: Developers::InvisiblizeNotification.name, recipient: invisible_developer.user, params: {
+  developer: invisible_developer,
+  message: reason.message,
+  next_steps: reason.next_steps
+})
 
 # InvisiblizeMailer#to_business
 invisible_business = User.find_by(email: "invisible@example.com").business


### PR DESCRIPTION
This PR presents two options when an admin marks a developer profile as invisible. Their profile can be too short/spammy or they aren't responding to messages from businesses.

This came directly from a business complaining that two folks never responded to them. Turns out, neither of them have responded to _anyone_!

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
