### PR TITLE
Fix issue where uploaded avatars won't preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## August
 
+* August 10 - Fixes an issue where uploaded avatars wouldn't render their preview #596
 * August 8 - railsdevs -> RailsDevs #595
 * August 6 - Fixes a bug where responding to messages via email wouldn't send #579 @benngarcia
 

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
   select(event) {
     const file = event.currentTarget.files[0]
     this.imageTarget.src = window.URL.createObjectURL(file)
+    this.imageTarget.srcset = window.URL.createObjectURL(file)
     this.imageTarget.classList.remove(this.visibilityClass)
     this.errorTarget.classList.add(this.visibilityClass)
   }


### PR DESCRIPTION
Fixes #592. Since we have `srcset` this "overrides" the `src` of an image. By only setting `src` we wouldn't change the preview.

This PR makes sure the Stimulus controller backing the preview updates both properties.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
