### PR TITLE
Stripe notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## August
 
+* August 17 - Send admins notifications on subscription changes #600
 * August 10 - Fixes an issue where uploaded avatars wouldn't render their preview #596
 * August 8 - railsdevs -> RailsDevs #595
 * August 6 - Fixes a bug where responding to messages via email wouldn't send #579 @benngarcia

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -40,4 +40,13 @@ class AdminMailer < ApplicationMailer
 
     mail(to: recipient.email, subject: @notification.email_subject)
   end
+
+  def subscription_change
+    @notification = params[:record].to_notification
+    recipient = params[:recipient]
+
+    @business = @notification.subscription.customer.owner.business
+
+    mail(to: recipient.email, subject: @notification.title)
+  end
 end

--- a/app/models/concerns/pay/subscription_extensions.rb
+++ b/app/models/concerns/pay/subscription_extensions.rb
@@ -1,0 +1,16 @@
+module Pay
+  module SubscriptionExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      after_commit :send_admin_notification
+    end
+
+    def send_admin_notification
+      Admin::SubscriptionChangeNotification.new(
+        subscription: self,
+        change: SubscriptionChanges.new(self).change
+      ).deliver_later(User.admin)
+    end
+  end
+end

--- a/app/models/concerns/pay/subscription_extensions.rb
+++ b/app/models/concerns/pay/subscription_extensions.rb
@@ -11,6 +11,8 @@ module Pay
         subscription: self,
         change: SubscriptionChanges.new(self).change
       ).deliver_later(User.admin)
+    rescue Pay::SubscriptionChanges::UnknownSubscriptionChange => e
+      Honeybadger.notify(e)
     end
   end
 end

--- a/app/models/pay/subscription_changes.rb
+++ b/app/models/pay/subscription_changes.rb
@@ -1,0 +1,26 @@
+module Pay
+  class SubscriptionChanges
+    private attr_reader :subscription
+
+    def initialize(subscription)
+      @subscription = subscription
+    end
+
+    def change
+      case subscription.previous_changes
+      in processor_plan: [nil, String]
+        :subscribed
+      in ends_at: [nil, Time]
+        :churned
+      in ends_at: [Time, _]
+        :resubscribed
+      in processor_plan: Array
+        :plan_changed
+      in data: [{pause_behavior: nil}, _]
+        :paused
+      in data: [_, {pause_behavior: nil}]
+        :unpaused
+      end
+    end
+  end
+end

--- a/app/models/pay/subscription_changes.rb
+++ b/app/models/pay/subscription_changes.rb
@@ -1,5 +1,11 @@
 module Pay
   class SubscriptionChanges
+    class UnknownSubscriptionChange < StandardError
+      def initialize(changes)
+        super("Unknown subscription change: #{changes}")
+      end
+    end
+
     private attr_reader :subscription
 
     def initialize(subscription)
@@ -20,6 +26,8 @@ module Pay
         :paused
       in data: [_, {pause_behavior: nil}]
         :unpaused
+      else
+        raise UnknownSubscriptionChange.new(subscription.previous_changes)
       end
     end
   end

--- a/app/notifications/admin/subscription_change_notification.rb
+++ b/app/notifications/admin/subscription_change_notification.rb
@@ -1,0 +1,37 @@
+module Admin
+  class SubscriptionChangeNotification < ApplicationNotification
+    deliver_by :database
+    deliver_by :email, mailer: "AdminMailer", method: :subscription_change
+
+    param :subscription, :change
+
+    def title
+      case change
+      when :subscribed
+        "New subscriber: #{plan.name} plan"
+      when :churned
+        "Churned subscriber: #{plan.name} plan"
+      when :resubscribed
+        "Resubscribed subscriber: #{plan.name} plan"
+      when :plan_changed
+        "Subscription changed: #{plan.name} plan"
+      when :paused
+        "Subscription paused: #{plan.name} plan"
+      when :unpaused
+        "Subscription resumed: #{plan.name} plan"
+      end
+    end
+
+    def subscription
+      params[:subscription]
+    end
+
+    def change
+      params[:change]
+    end
+
+    def plan
+      ::Businesses::Plan.with_processor_plan(subscription.processor_plan)
+    end
+  end
+end

--- a/app/views/admin_mailer/subscription_change.html.erb
+++ b/app/views/admin_mailer/subscription_change.html.erb
@@ -1,0 +1,1 @@
+<p><b><%= link_to @business.name, "mailto:#{@business.user.email}" %> (<%= @business.company %>)</b> updated <%= link_to "their subscription", notification_url(@notification.record) %>.</p>

--- a/app/views/admin_mailer/subscription_change.text.erb
+++ b/app/views/admin_mailer/subscription_change.text.erb
@@ -1,0 +1,4 @@
+<%= @business.name %> (<%= @business.company %>) updated their subscription.
+
+<%= @business.user.email %>
+<%= notification_url(@notification.record) %>

--- a/config/initializers/pay.rb
+++ b/config/initializers/pay.rb
@@ -10,3 +10,7 @@ Pay.setup do |config|
   config.automount_routes = true
   config.routes_path = "/pay"
 end
+
+Rails.application.config.to_prepare do
+  Pay::Subscription.include Pay::SubscriptionExtensions
+end

--- a/db/seeds/notifications.rb
+++ b/db/seeds/notifications.rb
@@ -35,3 +35,7 @@ Notification.find_or_create_by!(type: Admin::NewDeveloperNotification.name, reci
 # AdminMailer#potential_hire
 developer = User.find_by(email: "hired@example.com").developer
 Notification.find_or_create_by!(type: Admin::PotentialHireNotification.name, recipient: admin, params: {developer:})
+
+# AdminMailer#subscription_change
+subscription = business.user.subscriptions.first
+Notification.find_or_create_by!(type: Admin::SubscriptionChangeNotification.name, recipient: admin, params: {subscription:, change: :subscribed})

--- a/test/mailers/previews/admin_mailer_preview.rb
+++ b/test/mailers/previews/admin_mailer_preview.rb
@@ -18,4 +18,9 @@ class AdminMailerPreview < ActionMailer::Preview
     notification = Notification.where(type: Admin::PotentialHireNotification.to_s).first
     AdminMailer.with(record: notification, recipient: User.first).potential_hire
   end
+
+  def subscription_change
+    notification = Notification.where(type: Admin::SubscriptionChangeNotification.to_s).first
+    AdminMailer.with(record: notification, recipient: User.first).subscription_change
+  end
 end

--- a/test/models/pay/subscription_changes_test.rb
+++ b/test/models/pay/subscription_changes_test.rb
@@ -56,6 +56,15 @@ class Pay::SubscriptionChangesTest < ActiveSupport::TestCase
     assert_equal :unpaused, change
   end
 
+  test "unknown changes -> error" do
+    subscription = create_subscription!(pause_behavior: :void)
+    subscription.update!(data: nil)
+
+    assert_raises Pay::SubscriptionChanges::UnknownSubscriptionChange do
+      Pay::SubscriptionChanges.new(subscription).change
+    end
+  end
+
   def create_subscription!(ends_at: nil, pause_behavior: nil)
     Pay::Subscription.create!(
       customer: pay_customers(:one),

--- a/test/models/pay/subscription_changes_test.rb
+++ b/test/models/pay/subscription_changes_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class Pay::SubscriptionChangesTest < ActiveSupport::TestCase
+  test "subscribed: processor_plan nil -> present" do
+    subscription = create_subscription!
+    change = Pay::SubscriptionChanges.new(subscription).change
+    assert_equal :subscribed, change
+  end
+
+  test "churned: ends_at nil -> present" do
+    subscription = create_subscription!
+    subscription.update!(ends_at: Date.tomorrow)
+
+    change = Pay::SubscriptionChanges.new(subscription).change
+
+    assert_equal :churned, change
+  end
+
+  test "resubscribed: ends_at present -> nil" do
+    subscription = create_subscription!(ends_at: Date.tomorrow)
+    subscription.update!(ends_at: nil)
+
+    change = Pay::SubscriptionChanges.new(subscription).change
+
+    assert_equal :resubscribed, change
+  end
+
+  test "plan_changed: processor_plan present -> present" do
+    subscription = create_subscription!
+    subscription.update!(processor_plan: :new_plan)
+
+    change = Pay::SubscriptionChanges.new(subscription).change
+
+    assert_equal :plan_changed, change
+  end
+
+  test "paused: pause_behavior nil -> present" do
+    subscription = create_subscription!
+    subscription.update!(data: {
+      pause_behavior: :void
+    })
+
+    change = Pay::SubscriptionChanges.new(subscription).change
+
+    assert_equal :paused, change
+  end
+
+  test "unpaused: pause_behavior present -> nil" do
+    subscription = create_subscription!(pause_behavior: :void)
+    subscription.update!(data: {
+      pause_behavior: nil
+    })
+
+    change = Pay::SubscriptionChanges.new(subscription).change
+
+    assert_equal :unpaused, change
+  end
+
+  def create_subscription!(ends_at: nil, pause_behavior: nil)
+    Pay::Subscription.create!(
+      customer: pay_customers(:one),
+      name: "sub_name",
+      processor_id: :sub_id,
+      processor_plan: :processor_plan,
+      status: :active,
+      ends_at: ends_at,
+      data: {
+        pause_behavior: pause_behavior
+      }
+    )
+  end
+end


### PR DESCRIPTION
Send admins a notification (and email) when a subscription changes.

* New subscriber
* Churned subscriber
* Resubscribed subscriber
* Subscription changed
* Subscription paused
* Subscription resumed

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)