### PR TITLE
Expand User filtering to developer & business

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## August
 
+* August 21 - Expand `User` filtering to developer & business #608
 * August 19 - Removed developer Twitter handle from Open Graph tags #607
 * August 19 - Convert reusable `/admin` components to View Components #605
 * August 18 - Add basic admin user search #604

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,7 +10,7 @@ module Admin
     private
 
     def users(query)
-      User.filter_by_email(query)
+      User.search(query)
         .includes(developer: {avatar_attachment: :blob}, business: {avatar_attachment: :blob})
         .order(:email)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,14 @@ class User < ApplicationRecord
     inverse_of: :user_with_unread_messages
 
   scope :admin, -> { where(admin: true) }
-  scope :filter_by_email, ->(email) { where("email ILIKE ?", "%#{email}%") }
+
+  scope :search, ->(query) do
+    left_outer_joins(:developer, :business)
+      .where("email ILIKE ?", "%#{query}%")
+      .or(where("developers.name ILIKE ?", "%#{query}%"))
+      .or(where("businesses.contact_name ILIKE ?", "%#{query}%"))
+      .or(where("businesses.company ILIKE ?", "%#{query}%"))
+  end
 
   # Always remember when signing in with Devise.
   def remember_me

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,11 +28,12 @@ class User < ApplicationRecord
   scope :admin, -> { where(admin: true) }
 
   scope :search, ->(query) do
+    query = "%#{query}%"
     left_outer_joins(:developer, :business)
-      .where("email ILIKE ?", "%#{query}%")
-      .or(where("developers.name ILIKE ?", "%#{query}%"))
-      .or(where("businesses.contact_name ILIKE ?", "%#{query}%"))
-      .or(where("businesses.company ILIKE ?", "%#{query}%"))
+      .where("email ILIKE ?", query)
+      .or(where("developers.name ILIKE ?", query))
+      .or(where("businesses.contact_name ILIKE ?", query))
+      .or(where("businesses.company ILIKE ?", query))
   end
 
   # Always remember when signing in with Devise.

--- a/app/views/admin/users/_search.html.erb
+++ b/app/views/admin/users/_search.html.erb
@@ -3,7 +3,7 @@
     <%= form.label :query, t(".help"), class: "block text-sm font-medium text-gray-700" %>
     <div class="mt-1 flex rounded-md shadow-sm">
       <div class="relative flex items-stretch flex-grow focus-within:z-10">
-        <%= form.text_field :query, value: query, placeholder: "joe@railsdevs.com", autocomplete: "off", autofocus: true, class: "focus:ring-gray-500 focus:border-gray-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300" %>
+        <%= form.text_field :query, value: query, placeholder: "Joe Masilotti", autocomplete: "off", autofocus: true, class: "focus:ring-gray-500 focus:border-gray-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300" %>
       </div>
       <%= form.button type: "submit", class: "-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 text-sm font-medium rounded-r-md text-gray-700 bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500" do %>
         <%= inline_svg_tag "icons/solid/search.svg", class: "h-5 w-5 text-gray-400", aria_hidden: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,7 +116,7 @@ en:
         title: Users
       search:
         cta: Search
-        help: Filter users by email
+        help: Filter users by name, company, or email
   blocks:
     create:
       notice: "%{other_recipient} was blocked."

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,9 +27,10 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.pay_customer_name
   end
 
-  test "searching via email" do
-    assert_equal [users(:empty)], User.filter_by_email("user@EXAMPLE.com")
-    assert_equal [users(:admin)], User.filter_by_email("admin@")
-    assert_empty User.filter_by_email("joe")
+  test "search" do
+    assert_includes User.search("ADMIN@"), users(:admin)
+    assert_includes User.search("one"), users(:developer)
+    assert_includes User.search("owner"), users(:business)
+    assert_includes User.search("company"), users(:business)
   end
 end


### PR DESCRIPTION
This PR expands the existing email filtering on `/admin/users` to include:

* The name of developers
* The contact name of businesses
* The name of companies

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)