### PR TITLE
Update license year and note non-code copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## September
 
+* September 8 – Update license year and note non-code usage #629
 * September 8 – Remove part-time hiring plan from pricing page #628
 
 ## August

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Joe Masilotti
+Copyright (c) 2021-2022 Joe Masilotti
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Application monitoring is powered by [Scout APM](https://scoutapm.com). This hel
 
 Significant changes and product updates are documented in the [changelog](CHANGELOG.md).
 
+## License
+
+All code and documentation is copyright 2022 Joe Masilotti [under the MIT license](LICENSE).
+
+All other resources including, but not limited to, images, copy, and branding, are copyright 2022 Joe Masilotti and used by permission for this project only.
+
 ## Open source support
 
 RailsDevs uses a free or discounted open source plan from the following companies. Thank you for the support!


### PR DESCRIPTION
This PR updates the license year to 2022 and notes copyright information for non-code assets, like images and copy.

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [ ] ~I linted and tested the project with `bin/check`~
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)