### PR TITLE
Manual entry of a hiring fee collected out of band

### DIFF
--- a/app/models/open_startup/reporting.rb
+++ b/app/models/open_startup/reporting.rb
@@ -44,7 +44,7 @@ module OpenStartup
     def normalize_revenue
       log "Normalizing revenue..."
       Revenue.transaction do
-        Revenue.delete_all
+        Revenue.automated.delete_all
 
         monthly_charges = StripeTransaction.charge
           .group_by_month(:created).group(:description)

--- a/app/models/open_startup/revenue.rb
+++ b/app/models/open_startup/revenue.rb
@@ -2,7 +2,7 @@ module OpenStartup
   class Revenue < ApplicationRecord
     self.table_name = "open_startup_revenue"
 
-    scope :automated, ->{ where(manual: false) }
+    scope :automated, -> { where(manual: false) }
 
     validates :occurred_on, presence: true
     validates :description, presence: true

--- a/app/models/open_startup/revenue.rb
+++ b/app/models/open_startup/revenue.rb
@@ -2,6 +2,8 @@ module OpenStartup
   class Revenue < ApplicationRecord
     self.table_name = "open_startup_revenue"
 
+    scope :automated, ->{ where(manual: false) }
+
     validates :occurred_on, presence: true
     validates :description, presence: true
     validates :amount, numericality: {greater_than_or_equal_to: 0}

--- a/db/migrate/20220913131207_add_manual_flag_to_open_startup_revenues.rb
+++ b/db/migrate/20220913131207_add_manual_flag_to_open_startup_revenues.rb
@@ -1,0 +1,5 @@
+class AddManualFlagToOpenStartupRevenues < ActiveRecord::Migration[7.0]
+  def change
+    add_column :open_startup_revenue, :manual, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_26_195050) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_13_131207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -242,6 +242,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_26_195050) do
     t.decimal "amount", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "manual", default: false, null: false
   end
 
   create_table "open_startup_stripe_transactions", force: :cascade do |t|


### PR DESCRIPTION
This PR adds a flag to `OpenStartup::Revenue` to indicate if it was added manually or automated from Stripe. A business paid a hiring fee out of band, which Stripe doesn't account for. This enables me to manually add the fee so `/open` remains accurate.