### PR TITLE
Multiple celebration email fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## September
 
-* September 14 - Multiple Celebration Promotion emails can be sent #617 @sarvaiyanidhi
+* September 14 - Only ever send one Celebration Promotion email #617 @sarvaiyanidhi
 * September 13 - Impersonate users directly from `/admin/users` #627 @KarlHeitmann
 * September 13 - Move developer bio to own card in form and add more instructions #635 @rayhanw
 * September 8 - Send admins a notification when a `Hired::Form` is created #614 @sarvaiyanidhi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## September
 
+* September 14 - Multiple Celebration Promotion emails can be sent #617 @sarvaiyanidhi
 * September 13 - Impersonate users directly from `/admin/users` #627 @KarlHeitmann
 * September 13 - Move developer bio to own card in form and add more instructions #635 @rayhanw
 * September 8 - Send admins a notification when a `Hired::Form` is created #614 @sarvaiyanidhi

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -61,7 +61,7 @@ class Conversation < ApplicationRecord
   end
 
   def first_reply?(developer)
-    messages.where(sender: developer).one?
+    messages.where(sender: developer).one? && latest_message.sender == developer
   end
 
   private

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -138,11 +138,14 @@ class ConversationTest < ActiveSupport::TestCase
   test "first reply when a developer has sent exactly one message in this conversation" do
     conversation = conversations(:one)
     conversation.messages.destroy_all
-    conversation.messages.create!(sender: conversation.business, body: "<p>One Message.</p>")
-    conversation.messages.create!(sender: conversation.developer, body: "<p>Second Message.</p>")
+
+    conversation.messages.create!(sender: conversation.business, body: "From business #1")
+    refute conversation.first_reply?(conversation.developer)
+
+    conversation.messages.create!(sender: conversation.developer, body: "From developer #1")
     assert conversation.first_reply?(conversation.developer)
 
-    conversation.messages.create!(sender: conversation.developer, body: "Second message.")
+    conversation.messages.create!(sender: conversation.business, body: "From business #2")
     refute conversation.first_reply?(conversation.developer)
   end
 

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -137,6 +137,9 @@ class ConversationTest < ActiveSupport::TestCase
 
   test "first reply when a developer has sent exactly one message in this conversation" do
     conversation = conversations(:one)
+    conversation.messages.destroy_all
+    conversation.messages.create!(sender: conversation.business, body: "<p>One Message.</p>")
+    conversation.messages.create!(sender: conversation.developer, body: "<p>Second Message.</p>")
     assert conversation.first_reply?(conversation.developer)
 
     conversation.messages.create!(sender: conversation.developer, body: "Second message.")


### PR DESCRIPTION
PR fixes the issue related to multiple celebration promotion email triggered when business replies to conversation after first message from developer. More details in issue #617 

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)
