### PR TITLE
Show "Featured" badge in search results, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## September
 
+* September 15 - Show "Featured" badge in search results #642
 * September 14 - Only ever send one Celebration Promotion email #617 @sarvaiyanidhi
 * September 13 - Impersonate users directly from `/admin/users` #627 @KarlHeitmann
 * September 13 - Move developer bio to own card in form and add more instructions #635 @rayhanw

--- a/app/components/developers/card_component.html.erb
+++ b/app/components/developers/card_component.html.erb
@@ -1,5 +1,5 @@
-<%= tag.div class: "relative #{"border-b" if featured?}" do %>
-  <%= link_to developer, class: ["bg-white hover:bg-gray-50 px-4 py-6 sm:p-6 flex space-x-4 sm:space-x-8", "border-l-4 border-blue-400": featured?] do %>
+<%= tag.div class: class_names("relative", "border-b": highlight?) do %>
+  <%= link_to developer, class: class_names("bg-white hover:bg-gray-50 px-4 py-6 sm:p-6 flex space-x-4 sm:space-x-8", "border-l-4 border-blue-400": highlight?) do %>
     <div class="shrink-0">
       <%= render AvatarComponent.new(avatarable: developer, variant: :medium) %>
     </div>

--- a/app/components/developers/card_component.rb
+++ b/app/components/developers/card_component.rb
@@ -2,23 +2,25 @@ module Developers
   class CardComponent < ApplicationComponent
     with_collection_parameter :developer
 
-    attr_reader :developer
+    delegate :featured?, to: :developer
 
-    def initialize(developer:, featured: false)
+    private attr_reader :developer, :highlight_featured
+
+    def initialize(developer:, highlight_featured: false)
       @developer = developer
-      @featured = featured
+      @highlight_featured = highlight_featured
     end
 
     def hero
-      @developer.hero
+      developer.hero
     end
 
     def bio
-      @developer.bio
+      developer.bio
     end
 
-    def featured?
-      !!@featured
+    def highlight?
+      !!highlight_featured && featured?
     end
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,6 +6,8 @@ class Developer < ApplicationRecord
   include PersonName
   include PgSearch::Model
 
+  FEATURE_LENGTH = 1.week
+
   enum search_status: {
     actively_looking: 1,
     open: 2,
@@ -58,7 +60,7 @@ class Developer < ApplicationRecord
   scope :actively_looking_or_open, -> { where(search_status: [:actively_looking, :open, nil]) }
   scope :available, -> { where(available_on: ..Time.current.to_date) }
   scope :available_first, -> { where.not(available_on: nil).order(:available_on) }
-  scope :featured, -> { where("featured_at >= ?", 1.week.ago).order(featured_at: :desc) }
+  scope :featured, -> { where("featured_at >= ?", FEATURE_LENGTH.ago).order(featured_at: :desc) }
   scope :newest_first, -> { order(created_at: :desc) }
   scope :profile_reminder_notifications, -> { where(profile_reminder_notifications: true) }
   scope :visible, -> { where.not(search_status: :invisible).or(where(search_status: nil)) }
@@ -90,5 +92,9 @@ class Developer < ApplicationRecord
 
   def feature!
     touch(:featured_at)
+  end
+
+  def featured?
+    featured_at? && featured_at >= FEATURE_LENGTH.ago
   end
 end

--- a/app/views/developers/index.html.erb
+++ b/app/views/developers/index.html.erb
@@ -46,7 +46,7 @@
       <%= render Developers::CountComponent.new(count: @query.pagy.count, total: @developers_count) %>
 
       <% if @query.records.any? %>
-        <%= render Developers::CardComponent.with_collection(@query.featured_records, featured: true) %>
+        <%= render Developers::CardComponent.with_collection(@query.featured_records, highlight_featured: true) %>
 
         <%= render PagyPaginatorComponent.new(id: "developers", pagy: @query.pagy, url_array: [:developers], container_classes: "divide-y divide-gray-200", options: @query.filters) do |component| %>
           <% component.loading_icon do %>

--- a/test/components/developers/card_component_test.rb
+++ b/test/components/developers/card_component_test.rb
@@ -31,14 +31,22 @@ module Developers
       assert_selector("span", text: "Available now")
     end
 
-    test "renders the accent border and badge if featured" do
-      render_inline(CardComponent.new(developer: @developer, featured: true))
-      assert_selector "a.border-l-4.border-blue-400"
-      assert_text I18n.t("developers.card_component.featured")
-
+    test "renders the badge if featured" do
+      @developer.feature!
       render_inline(CardComponent.new(developer: @developer))
+      assert_text I18n.t("developers.card_component.featured")
+    end
+
+    test "highlights the border if featured and the option is set" do
+      render_inline(CardComponent.new(developer: @developer, highlight_featured: true))
       assert_no_selector "a.border-l-4.border-blue-400"
-      assert_no_text I18n.t("developers.card_component.featured")
+
+      @developer.feature!
+      render_inline(CardComponent.new(developer: @developer, highlight_featured: false))
+      assert_no_selector "a.border-l-4.border-blue-400"
+
+      render_inline(CardComponent.new(developer: @developer, highlight_featured: true))
+      assert_selector "a.border-l-4.border-blue-400"
     end
   end
 end

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -198,15 +198,19 @@ class DeveloperTest < ActiveSupport::TestCase
 
   test "featured developers were featured within the last week" do
     developer = developers(:one)
+    refute developer.featured?
     refute_includes Developer.featured, developer
 
     developer.feature!
+    assert developer.featured?
     assert_includes Developer.featured, developer
 
     travel 7.days
+    assert developer.featured?
     assert_includes Developer.featured, developer
 
     travel 1.second
+    refute developer.featured?
     refute_includes Developer.featured, developer
 
     travel_back


### PR DESCRIPTION
This PR shows the "Featured" badge (for featured developers) in the search results, not just at the top where the card is highlighted. It paves the way for #641 where multiple badges could be set on the same developer.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)