### PR TITLE
Publicly shareable developer profile URLs

### DIFF
--- a/app/components/developers/primary_action_component.html.erb
+++ b/app/components/developers/primary_action_component.html.erb
@@ -3,6 +3,13 @@
     <%= inline_svg_tag "icons/solid/pencil.svg", class: "-ml-1 mr-3 h-5 w-5", aria_hidden: true %>
     <%= t("developers.show.edit") %>
   <% end %>
+  <%= tag.div data: {controller: "clipboard", clipboard_visibility_class: "hidden", clipboard_content_value: share_url, clipboard_html_content_value: share_url} do %>
+    <button data-action="clipboard#copy clipboard#toggle" type="button" class="shrink-0 mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+      <%= inline_svg_tag "icons/solid/document-duplicate.svg", class: "-ml-1 mr-2 h-5 w-5 text-gray-400", data: {clipboard_target: "toggleable"}, aria_hidden: true %>
+      <%= inline_svg_tag "icons/solid/check.svg", class: "-ml-1 mr-2 h-5 w-5 text-gray-400 hidden", data: {clipboard_target: "toggleable"}, aria_hidden: true %>
+      <%= t("developers.show.share") %>
+    </button>
+  <% end %>
 <% elsif conversation.present? %>
   <%= link_to conversation_path(conversation), class: "shrink-0 mt-4 md:mt-0 inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" do %>
     <%= inline_svg_tag "icons/solid/mail.svg", class: "-ml-1 mr-3 h-5 w-5", aria_hidden: true %>

--- a/app/components/developers/primary_action_component.rb
+++ b/app/components/developers/primary_action_component.rb
@@ -15,5 +15,9 @@ module Developers
     def conversation
       Conversation.find_by(developer:, business:)
     end
+
+    def share_url
+      developer.share_url(developer_url(@developer))
+    end
   end
 end

--- a/app/components/users/paywalled_component.rb
+++ b/app/components/users/paywalled_component.rb
@@ -40,7 +40,7 @@ module Users
     end
 
     def valid_public_profile_access?
-      @paywalled&.public_profile_key == @public_key
+      @paywalled&.public_profile_key == @public_key && @paywalled&.public_profile_key.present?
     end
   end
 end

--- a/app/components/users/paywalled_component.rb
+++ b/app/components/users/paywalled_component.rb
@@ -1,15 +1,16 @@
 module Users
   class PaywalledComponent < ApplicationComponent
-    def initialize(user:, paywalled:, size: nil, title: nil, description: nil)
+    def initialize(user:, paywalled:, size: nil, title: nil, description: nil, public_key: nil)
       @user = user
       @paywalled = paywalled
       @size = size
       @title = title
       @description = description
+      @public_key = public_key
     end
 
     def render_content?
-      customer? || owner?
+      customer? || owner? || valid_public_profile_access?
     end
 
     def small?
@@ -36,6 +37,10 @@ module Users
 
     def owner?
       @paywalled&.user == @user && @user.present?
+    end
+
+    def valid_public_profile_access?
+      @paywalled&.public_profile_key == @public_key
     end
   end
 end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -42,6 +42,7 @@ class DevelopersController < ApplicationController
 
   def show
     @developer = find_developer!
+    @public_key = params[:key]
     authorize @developer
   end
 

--- a/app/javascript/src/clipboard.js
+++ b/app/javascript/src/clipboard.js
@@ -1,8 +1,8 @@
 class Clipboard {
   static copy({text, html}) {
     const data = [
-      this.clipboardItem({type: "text/plain", content: text}),
-      this.clipboardItem({type: "text/html", content: html})
+      this.clipboardItem({type: "text/plain", content: text})
+     // this.clipboardItem({type: "text/html", content: html})
     ]
 
     navigator.clipboard.write(data).then(

--- a/app/models/concerns/public_profile.rb
+++ b/app/models/concerns/public_profile.rb
@@ -1,36 +1,35 @@
 module PublicProfile
-
   extend ActiveSupport::Concern
-  
+
   def share_url(url)
-    update_public_profile_key if self.public_profile_key.blank?    
-    share_url = form_url(url, self.public_profile_key)
+    update_public_profile_key if public_profile_key.blank?
+    form_url(url, public_profile_key)
   end
 
   private
 
-    def form_url(url, query_param)
-      parsed = URI.parse(url)
-      query = if parsed.query
-              CGI.parse(parsed.query)
-            else
-              {}
-            end
-
-      query['key'] = query_param
-
-      parsed.query = URI.encode_www_form(query)
-      parsed.to_s
+  def form_url(url, query_param)
+    parsed = URI.parse(url)
+    query = if parsed.query
+      CGI.parse(parsed.query)
+    else
+      {}
     end
 
-    def update_public_profile_key
-      update!(public_profile_key: generate_token)
-    end
+    query["key"] = query_param
 
-    def generate_token
-      loop do
-        public_key = SecureRandom.hex(10)
-        break public_key unless self.class.find_by(public_profile_key: public_key)
-      end
+    parsed.query = URI.encode_www_form(query)
+    parsed.to_s
+  end
+
+  def update_public_profile_key
+    update!(public_profile_key: generate_token)
+  end
+
+  def generate_token
+    loop do
+      public_key = SecureRandom.hex(10)
+      break public_key unless self.class.find_by(public_profile_key: public_key)
     end
+  end
 end

--- a/app/models/concerns/public_profile.rb
+++ b/app/models/concerns/public_profile.rb
@@ -1,0 +1,36 @@
+module PublicProfile
+
+  extend ActiveSupport::Concern
+  
+  def share_url(url)
+    update_public_profile_key if self.public_profile_key.blank?    
+    share_url = form_url(url, self.public_profile_key)
+  end
+
+  private
+
+    def form_url(url, query_param)
+      parsed = URI.parse(url)
+      query = if parsed.query
+              CGI.parse(parsed.query)
+            else
+              {}
+            end
+
+      query['key'] = query_param
+
+      parsed.query = URI.encode_www_form(query)
+      parsed.to_s
+    end
+
+    def update_public_profile_key
+      update!(public_profile_key: generate_token)
+    end
+
+    def generate_token
+      loop do
+        public_key = SecureRandom.hex(10)
+        break public_key unless self.class.find_by(public_profile_key: public_key)
+      end
+    end
+end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -7,6 +7,7 @@ class Developer < ApplicationRecord
   include Hashid::Rails
   include PersonName
   include PgSearch::Model
+  include PublicProfile
 
   FEATURE_LENGTH = 1.week
   RECENTLY_ACTIVE_LENGTH = 1.week

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -15,7 +15,7 @@
     <%= render RoleLevels::Component.new(developer.role_level) %>
   <% end %>
 
-  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large, public_key: @public_key) do %>
+  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large, public_key: public_key) do %>
     <%= render RenderableComponent.new("space-y-3 pt-4") do %>
       <%= render ExternalLinkComponent.new(developer.website) %>
       <%= render SocialLinkComponent.new(developer.github, :github) %>

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -15,7 +15,7 @@
     <%= render RoleLevels::Component.new(developer.role_level) %>
   <% end %>
 
-  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large) do %>
+  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large, public_key: @public_key) do %>
     <%= render RenderableComponent.new("space-y-3 pt-4") do %>
       <%= render ExternalLinkComponent.new(developer.website) %>
       <%= render SocialLinkComponent.new(developer.github, :github) %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -17,7 +17,7 @@
             <div class="md:flex md:items-start md:justify-between md:space-x-4 lg:border-b lg:pb-6">
               <div class="w-full">
                 <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
-                <%= render Users::PaywalledComponent.new(user: current_user, paywalled: @developer, size: :small) do %>
+                <%= render Users::PaywalledComponent.new(user: current_user, paywalled: @developer, size: :small, public_key: @public_key) do %>
                   <div class="mt-2 flex items-center text-sm font-medium text-gray-500">
                     <%= inline_svg_tag "icons/solid/user.svg", class: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400", aria_hidden: true %>
                     <%= @developer.name %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -31,7 +31,7 @@
             <%= render Developers::BadgesComponent.new(@developer) %>
 
             <aside class="mt-8 lg:hidden">
-              <%= render "details", developer: @developer %>
+              <%= render "details", developer: @developer, public_key: @public_key %>
             </aside>
 
             <div class="pb-3 lg:pb-0">
@@ -44,7 +44,7 @@
         </div>
 
         <aside class="hidden lg:block lg:pl-8">
-          <%= render "details", developer: @developer %>
+          <%= render "details", developer: @developer, public_key: @public_key %>
         </aside>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,6 +393,7 @@ en:
       edit: Edit
       hire: Hire me
       message: Message
+      share: Share
     update:
       updated: Your profile was updated!
   dir: ltr

--- a/db/migrate/20220919170633_add_public_profile_key_to_developers.rb
+++ b/db/migrate/20220919170633_add_public_profile_key_to_developers.rb
@@ -1,0 +1,6 @@
+class AddPublicProfileKeyToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :public_profile_key, :string
+    add_index :developers, :public_profile_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_13_131207) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_19_170633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -110,6 +110,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_13_131207) do
     t.datetime "featured_at"
     t.boolean "profile_reminder_notifications", default: true
     t.string "stack_overflow"
+    t.string "public_profile_key"
+    t.index ["public_profile_key"], name: "index_developers_on_public_profile_key", unique: true
     t.index ["textsearchable_index_col"], name: "textsearchable_index", using: :gin
     t.index ["user_id"], name: "index_developers_on_user_id"
   end


### PR DESCRIPTION
Implemented feature to publicly share developer URL using public profile key.

- [x] Add a new column to the database, developers.public_profile_key
- [x] Unhide hidden information on a developers profile page if this key matches from the key param (e.g. /developers/abc123?key=xyz987)
- [x] Add a new button next to “Edit” when viewing your own developer profile titled “Share”. When clicked:
  - [x] Generate the public profile key via Secure Random (if not already generated)
   - [x]  Copy the full URL (with key param) to the clipboard


## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)
