### PR TITLE
Compress HTML output via gzip

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,9 @@ module Railsdevs
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Compress HTML output with gzip.
+    config.middleware.use Rack::Deflater
+
     # Don't generate system test files.
     config.generators.system_tests = nil
 


### PR DESCRIPTION
https://andycroll.com/ruby/compress-your-rails-html-responses-on-heroku/

### PageSpeed (mobile) before deploying

* `https://railsdevs.com` - 95, 97, 97
* `https://railsdevs.com/developers` - 85, 45, 78
* `https://railsdevs.com/developers/1` - 69, 69, 63