### PR TITLE
Bump Turbo Package to 7.2.2 & Gem version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### October
 
+* October 19 - Upgrade to Turbo 7.2.2 #683 @sarvaiyanidhi
 * October 12 - Remove manual payments and account for payments made via ACH #681
 * October 12 - Update to rails 7.0.4 #682 @kaushikhande
 * October 7 - Bring back 1x and 2x avatar variants and remove lazy image loading #680 @jkostolansky

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.6"
 gem "sprockets-rails", "~> 3.4"
 gem "stimulus-rails", "~> 0.7"
-gem "turbo-rails", "~> 1.0"
+gem "turbo-rails", "~> 1.3.1"
 gem "view_component", "~> 2.69"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,8 +412,9 @@ GEM
     thor (1.2.1)
     timeout (0.3.0)
     timezone_finder (1.5.7)
-    turbo-rails (1.0.0)
+    turbo-rails (1.3.1)
       actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -498,7 +499,7 @@ DEPENDENCIES
   stripe (~> 6.5.0)
   tarpon (~> 0.4.0)
   timezone_finder (~> 1.5.7)
-  turbo-rails (~> 1.0)
+  turbo-rails (~> 1.3.1)
   tzinfo-data
   view_component (~> 2.69)
   webdrivers

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
-    "@hotwired/turbo-rails": "^7.1.0",
+    "@hotwired/turbo-rails": "^7.2.2",
     "@rails/activestorage": "^7.0.0",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,18 +28,18 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
 
-"@hotwired/turbo-rails@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.0.tgz#63df3f0e11aea7c451983266c80ad8896f310952"
-  integrity sha512-eB/PTZQYl7dPm51AfBwm0sBpohJ7eir/JmuOfwJG297lEEA8sFcvpxVON/87Ne97OyAOcORZtLpX0KB+t9afyw==
+"@hotwired/turbo-rails@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.2.2.tgz#577d0d2d8253f395e6c922e3afaf6a9483a75487"
+  integrity sha512-UlHB++XYlNprpfro4YbywUXFC8QuqH59I+xuU26WMu1mE+RbV2EVS7ARlcUlwzl3PFgsKgJ+xxrJ4HW5gZkJdQ==
   dependencies:
-    "@hotwired/turbo" "^7.1.0"
-    "@rails/actioncable" "^6.0.0"
+    "@hotwired/turbo" "^7.2.2"
+    "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
-  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
+"@hotwired/turbo@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.2.tgz#69e1f4be7f468690fa31791099e2a837e88c9518"
+  integrity sha512-YfTHwnur3tDFS/D5JYstU+09Z3bvCF6euqqXajHAks2lTSIDbLc8gMp8yLomD+cAC337h1wnv0oWduK6+6pUDw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -62,10 +62,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rails/actioncable@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.4.tgz#c3c5a9f8302c429af9722b6c50ab48049016d2a3"
-  integrity sha512-0LmSKJTuo2dL6BQ+9xxLnS9lbkyfz2mBGeBnQ2J7o9Bn0l0q+ZC6VuoZMZZXPvABI4QT7Nfknv5WhfKYL+boew==
+"@rails/actioncable@^7.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
+  integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
 
 "@rails/activestorage@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
Have updated Turbo to latest version - #683 
- Have updated package to latest release of [7.2.2](https://www.npmjs.com/package/@hotwired/turbo-rails/v/7.2.2)
- Have updated Gem version to latest release of [1.3.1](https://github.com/hotwired/turbo-rails)

## Pull request checklist

- [ ] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)

Have tested below features in the application after updating to latest version

- [x] Registration flow for both developer and business
- [x] Subscription for business user
- [x] Sending messages between developers and business
- [x] Sending message with keyboard shortcut
- [x] Developer Hiring form submission 
- [x] Block Conversion feature
- [x] Admin mark profile as invisible
- [x] Filter developer profiles