### PR TITLE
Add "Tech Stack" to your developer profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### October
 
+* October 20 - Add "Tech Stack" to your developer profile
 * October 19 - Upgrade to Turbo 7.2.2 #683 @sarvaiyanidhi
 * October 12 - Remove manual payments and account for payments made via ACH #681
 * October 12 - Update to rails 7.0.4 #682 @kaushikhande

--- a/app/components/tech_stack_component.html.erb
+++ b/app/components/tech_stack_component.html.erb
@@ -1,0 +1,2 @@
+<h2 class="text-sm font-medium text-gray-500 mb-3">Tech Stack</h2>
+<span class="text-gray-900 text-sm font-medium"><%= body %></span>

--- a/app/components/tech_stack_component.rb
+++ b/app/components/tech_stack_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TechStackComponent < ApplicationComponent
+  def initialize(body)
+    @body = body
+  end
+
+  def render?
+    @body.present?
+  end
+
+  def body
+    @body
+  end
+end

--- a/app/components/tech_stack_component.rb
+++ b/app/components/tech_stack_component.rb
@@ -9,7 +9,5 @@ class TechStackComponent < ApplicationComponent
     @body.present?
   end
 
-  def body
-    @body
-  end
+  attr_reader :body
 end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -87,6 +87,7 @@ class DevelopersController < ApplicationController
       :search_status,
       :search_query,
       :profile_reminder_notifications,
+      :tech_stack,
       location_attributes: [:city, :state, :country],
       role_type_attributes: RoleType::TYPES,
       role_level_attributes: RoleLevel::TYPES

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -25,6 +25,12 @@
     <% end %>
   <% end %>
 
+  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large) do %>  
+    <%= render RenderableComponent.new("space-y-3 pt-4") do %> 
+      <%= render TechStackComponent.new(developer.tech_stack) %>
+    <% end %>
+  <% end %>
+
   <%= render RenderableComponent.new("space-y-3 pt-4") do %>
     <%= render Locations::Component.new(developer.location) %>
     <%= render Locations::TimeZoneComponent.new(developer.location) %>

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -25,8 +25,8 @@
     <% end %>
   <% end %>
 
-  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large) do %>  
-    <%= render RenderableComponent.new("space-y-3 pt-4") do %> 
+  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large) do %>
+    <%= render RenderableComponent.new("space-y-3 pt-4") do %>
       <%= render TechStackComponent.new(developer.tech_stack) %>
     <% end %>
   <% end %>

--- a/app/views/developers/_form.html.erb
+++ b/app/views/developers/_form.html.erb
@@ -365,6 +365,28 @@
     <div class="bg-white shadow mt-8 px-4 py-5 lg:rounded-lg sm:p-6">
       <div class="md:grid md:grid-cols-3 md:gap-6">
         <div class="md:col-span-1">
+          <h3 class="text-lg font-medium leading-6 text-gray-900"><%= t(".tech_stack.title") %></h3>
+          <p class="mt-1 text-sm text-gray-500"><%= t(".tech_stack.help_text") %></p>
+        </div>
+        <div class="mt-5 md:mt-0 md:col-span-2">
+          <div class="space-y-6">
+            <div class="sm:col-span-3">
+              <%= form.label :tech_stack, class: "block text-sm font-medium text-gray-700" %>
+              <div class="mt-1 flex rounded-md shadow-sm">
+                <!-- <span class="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm"> -->
+                <!--   https:// -->
+                <!-- </span> -->
+                <%= form.text_field :tech_stack, class: "flex-1 focus:ring-gray-500 focus:border-gray-500 block w-full min-w-0 rounded-none rounded-r-md sm:text-sm border-gray-300" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white shadow mt-8 px-4 py-5 lg:rounded-lg sm:p-6">
+      <div class="md:grid md:grid-cols-3 md:gap-6">
+        <div class="md:col-span-1">
           <h3 id="notifications" class="text-lg font-medium leading-6 text-gray-900"><%= t(".notifications.title") %></h3>
         </div>
         <div class="mt-5 md:mt-0 md:col-span-2">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,9 +300,6 @@ en:
       online_presence:
         help_text: Where can people learn more about you and your work?
         title: Online presence
-      tech_stack:
-        help_text: Which Ruby, Rails, Javascript, Database, Devops, etc technologies are you familiar with?
-        title: Tech Stack
       preferred_compensation:
         description: From my experience as a freelancer, compensation should be discussed only after the details of a project or job are known.
         more_info: More info on this decision
@@ -333,6 +330,9 @@ en:
         not_interested_help_text: Your profile will not appear in search results.
         open_help_text: Companies can still find you, but you won't appear on the homepage.
         title: Search status
+      tech_stack:
+        help_text: Which Ruby, Rails, Javascript, Database, Devops, etc technologies are you familiar with?
+        title: Tech Stack
       title: Your developer profile
       updating: Updating...
       work_preferences:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,9 @@ en:
       online_presence:
         help_text: Where can people learn more about you and your work?
         title: Online presence
+      tech_stack:
+        help_text: Which Ruby, Rails, Javascript, Database, Devops, etc technologies are you familiar with?
+        title: Tech Stack
       preferred_compensation:
         description: From my experience as a freelancer, compensation should be discussed only after the details of a project or job are known.
         more_info: More info on this decision

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -117,6 +117,9 @@ es:
       online_presence:
         help_text: "¿Dónde puede la gente aprender más sobre ti y tu trabajo?"
         title: Presencia en línea
+      tech_stack:
+        help_text: ¿Con qué tecnologías Ruby, Rails, Javascript, Database, Devops, etc. está familiarizado?
+        title: Pila de tecnología
       preferred_compensation:
         description: Desde mi experiencia como freelancer, la remuneración debe de ser discutida después de conocer los detalles del proyecto o trabajo.
         more_info: Más información sobre esta decisión

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -117,9 +117,6 @@ es:
       online_presence:
         help_text: "¿Dónde puede la gente aprender más sobre ti y tu trabajo?"
         title: Presencia en línea
-      tech_stack:
-        help_text: ¿Con qué tecnologías Ruby, Rails, Javascript, Database, Devops, etc. está familiarizado?
-        title: Pila de tecnología
       preferred_compensation:
         description: Desde mi experiencia como freelancer, la remuneración debe de ser discutida después de conocer los detalles del proyecto o trabajo.
         more_info: Más información sobre esta decisión
@@ -148,6 +145,9 @@ es:
         not_interested_help_text: Tu perfil estará claramente marcado de que no estás buscando trabajo.
         open_help_text: Las empresas aún pueden encontrarte, pero no aparecerás en la página de inicio.
         title: Estado de búsqueda
+      tech_stack:
+        help_text: "¿Con qué tecnologías Ruby, Rails, Javascript, Database, Devops, etc. está familiarizado?"
+        title: Pila de tecnología
       title: Tu perfil de desarrollador
       updating: Subiendo...
       work_preferences:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,6 +300,9 @@ fr:
       online_presence:
         help_text: Où peut-on en apprendre davantage sur vous et votre travail ?
         title: Présence en ligne
+      tech_stack:
+        help_text: Quelles technologies Ruby, Rails, Javascript, Database, Devops, etc. connaissez-vous ? 
+        title: Pile technologique
       preferred_compensation:
         description: D'après mon expérience en tant que freelance, la rémunération ne doit être discutée qu'une fois les détails du projet ou du travail connus.
         more_info: Plus d'informations sur cette décision

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -300,9 +300,6 @@ fr:
       online_presence:
         help_text: Où peut-on en apprendre davantage sur vous et votre travail ?
         title: Présence en ligne
-      tech_stack:
-        help_text: Quelles technologies Ruby, Rails, Javascript, Database, Devops, etc. connaissez-vous ? 
-        title: Pile technologique
       preferred_compensation:
         description: D'après mon expérience en tant que freelance, la rémunération ne doit être discutée qu'une fois les détails du projet ou du travail connus.
         more_info: Plus d'informations sur cette décision
@@ -333,6 +330,9 @@ fr:
         not_interested_help_text: Votre profil n'apparaîtra pas dans les résultats de recherche.
         open_help_text: Les entreprises peuvent toujours vous trouver, mais vous n'apparaîtrez pas sur la page d'accueil.
         title: Statut de recherche
+      tech_stack:
+        help_text: Quelles technologies Ruby, Rails, Javascript, Database, Devops, etc. connaissez-vous ?
+        title: Pile technologique
       title: Votre profil de développeur
       updating: Mise à jour...
       work_preferences:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -123,6 +123,9 @@ pt-BR:
       online_presence:
         help_text: Onde as pessoas podem saber mais sobre você e seu trabalho?
         title: Presença online
+      tech_stack:
+        help_text: Quais tecnologias Ruby, Rails, Javascript, Database, Devops, etc você conhece?
+        title: Pilha de tecnologia
       preferred_compensation:
         description: Na minha experiência como autônomo, a remuneração só deve ser discutida após os detalhes do projeto ou trabalho sejam conhecidos.
         more_info: Mais informações sobre essa decisão

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -123,9 +123,6 @@ pt-BR:
       online_presence:
         help_text: Onde as pessoas podem saber mais sobre você e seu trabalho?
         title: Presença online
-      tech_stack:
-        help_text: Quais tecnologias Ruby, Rails, Javascript, Database, Devops, etc você conhece?
-        title: Pilha de tecnologia
       preferred_compensation:
         description: Na minha experiência como autônomo, a remuneração só deve ser discutida após os detalhes do projeto ou trabalho sejam conhecidos.
         more_info: Mais informações sobre essa decisão
@@ -154,6 +151,9 @@ pt-BR:
         not_interested_help_text: Seu perfil será claramente marcado que você não está buscando trabalho.
         open_help_text: Empresas podem achar você, mas você não aparecerá na página principal.
         title: Status de busca
+      tech_stack:
+        help_text: Quais tecnologias Ruby, Rails, Javascript, Database, Devops, etc você conhece?
+        title: Pilha de tecnologia
       title: Seu perfil
       updating: Enviando...
       work_preferences:

--- a/db/migrate/20221020114604_add_tech_stack_to_developers.rb
+++ b/db/migrate/20221020114604_add_tech_stack_to_developers.rb
@@ -1,0 +1,5 @@
+class AddTechStackToDevelopers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :tech_stack, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_07_145250) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_20_114604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_145250) do
     t.datetime "featured_at"
     t.boolean "profile_reminder_notifications", default: true
     t.string "stack_overflow"
+    t.string "tech_stack"
     t.index ["textsearchable_index_col"], name: "textsearchable_index", using: :gin
     t.index ["user_id"], name: "index_developers_on_user_id"
   end

--- a/test/components/tech_stack_component_test.rb
+++ b/test/components/tech_stack_component_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TechStackComponentTest < ViewComponent::TestCase
+  # def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(TechStackComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  # end
+ 
+  test "renders nothing with a blank body" do
+    component = TechStackComponent.new("")
+    render_inline(component)
+    refute_component_rendered
+  end
+end

--- a/test/components/tech_stack_component_test.rb
+++ b/test/components/tech_stack_component_test.rb
@@ -4,12 +4,12 @@ require "test_helper"
 
 class TechStackComponentTest < ViewComponent::TestCase
   # def test_component_renders_something_useful
-    # assert_equal(
-    #   %(<span>Hello, components!</span>),
-    #   render_inline(TechStackComponent.new(message: "Hello, components!")).css("span").to_html
-    # )
+  # assert_equal(
+  #   %(<span>Hello, components!</span>),
+  #   render_inline(TechStackComponent.new(message: "Hello, components!")).css("span").to_html
+  # )
   # end
- 
+
   test "renders nothing with a blank body" do
     component = TechStackComponent.new("")
     render_inline(component)


### PR DESCRIPTION
A developer can write technologies (in whatever freeform) he/she wants to get displayed in the tech stack section on right sidebar of the developer#show.

Most of the Railsdevs also use other technologies such as PostgreSQL, MySQL, CouchDB, VueJS, ReactJS, EmberJS, AWS, Google Cloud, etc and it might be a good option to just write/display the technologies one is confortable with.

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)
