### PR TITLE
Multiple Tailwind CSS configs (for the redesign)

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,5 @@ web: bin/rails server -p 3000
 worker: bundle exec sidekiq
 js: yarn build --watch
 css: yarn build:css --watch
+redesign: yarn build:redesign --watch
 stripe: stripe listen --forward-to localhost:3000/pay/webhooks/stripe

--- a/app/assets/stylesheets/redesign.tailwind.css
+++ b/app/assets/stylesheets/redesign.tailwind.css
@@ -1,4 +1,4 @@
-@config "./../../../tailwind.config.js";
+@config "./../../../redesign.config.js";
 
 @import "tailwindcss/base";
 @import "tailwindcss/components";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,9 @@ module ApplicationHelper
   def hotwire_livereload_tags
     super if Rails.env.development?
   end
+
+  def stylesheet_design_tag
+    stylesheet = Feature.enabled?(:redesign) ? "redesign" : "application"
+    stylesheet_link_tag stylesheet, media: "all", "data-turbo-track": "reload"
+  end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -6,7 +6,7 @@ class Feature
     when :paywalled_search_results
       !Rails.env.production?
     when :redesign
-      false
+      ENV.fetch("REDESIGN", false)
     end
   end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -5,6 +5,8 @@ class Feature
       !Rails.env.production?
     when :paywalled_search_results
       !Rails.env.production?
+    when :redesign
+      false
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
     <%= render "shared/favicon_tags" %>
     <%= render AlternateLinksComponent.new %>
 
-    <%= stylesheet_link_tag "fonts", "application", media: "all", "data-turbo-track": "reload" %>
+    <%= stylesheet_design_tag %>
+    <%= stylesheet_link_tag "fonts", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
     <%= analytics_tag %>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
-    "build:css": "tailwindcss --postcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css"
+    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css",
+    "build:redesign": "tailwindcss -i ./app/assets/stylesheets/redesign.tailwind.css -o ./app/assets/builds/redesign.css"
   }
 }

--- a/redesign.config.js
+++ b/redesign.config.js
@@ -1,0 +1,43 @@
+const defaultTheme = require("tailwindcss/defaultTheme")
+const colors = require("tailwindcss/colors")
+
+module.exports = {
+  plugins: [
+    require("@tailwindcss/forms"),
+    require("@tailwindcss/aspect-ratio"),
+    require("@tailwindcss/typography"),
+    require('@tailwindcss/line-clamp'),
+  ],
+
+  content: [
+    "./app/assets/**/*.svg",
+    "./app/components/**/*.{rb,html,html.erb,yml}",
+    "./app/helpers/**/*.rb",
+    "./app/javascript/**/*.js",
+    "./app/models/field_error_tag_builder.rb",
+    "./app/views/**/*.html.erb",
+    "./config/utility_classes.yml"
+  ],
+
+  theme: {
+    extend: {
+      colors: {
+        red: colors.rose,
+      },
+      fontFamily: {
+        sans: ["Inter var", ...defaultTheme.fontFamily.sans],
+        serif: ["Merriweather", "serif"],
+      },
+      animation: {
+        "reverse-spin": "reverse-spin 1.5s linear infinite"
+      },
+      keyframes: {
+        "reverse-spin": {
+          from: {
+            transform: "rotate(360deg)"
+          },
+        },
+      },
+    },
+  },
+}

--- a/redesign.config.js
+++ b/redesign.config.js
@@ -20,10 +20,40 @@ module.exports = {
   ],
 
   theme: {
-    extend: {
-      colors: {
-        red: colors.rose,
+    colors: {
+      transparent: "transparent",
+      current: "currentColor",
+      gray: colors.neutral,
+      white: colors.white,
+      navy: {
+        DEFAULT: "#141B2F",
+        mid: "#898D97",
+        lightest: "#E7E8EA"
       },
+      salmon: {
+        dark: "#E71A04",
+        DEFAULT: "#FC6250",
+        mid: "#FEB1A7",
+        light: "#FFE7E5",
+        lighest: "#FFF7F6"
+      },
+      teal: {
+        dark: "#18766F",
+        DEFAULT: "#1E9188",
+        mid: "#8EC8C3",
+        lightest: "#E8F4F3"
+      },
+      green: {
+        dark: "#3B6039",
+        DEFAULT: "#80CB7B",
+        mid: "#BFE5BD",
+        lightest: "#DFF2DE"
+      },
+      typography: {
+        DEFAULT: "#333333"
+      }
+    },
+    extend: {
       fontFamily: {
         sans: ["Inter var", ...defaultTheme.fontFamily.sans],
         serif: ["Merriweather", "serif"],


### PR DESCRIPTION
This PR closes #690 by introducing a second Tailwind CSS configuration for the redesign. It also adds the branded colors: navy, salmon, teal, and green!

<img width="860" alt="image" src="https://user-images.githubusercontent.com/2092156/197077198-e208fe42-28c5-41e1-a9c9-8c8775374ff6.png">

I went with "light" vs. "dark" for color names instead of numbers because there aren't 9 of each color. And I didn't want to have to guess if the "light" version was 200 or 100 for different colors.

To enable the redesign set the `REDESIGN` environment variable. You can do this when running the server locally via:

```bash
$ ENABLE_REDESIGN=1 bin/dev
```

Note that none of these colors are actually being used yet. So when enabling the redesign the site will actually look _less_ colorful than before! (Because red, yellow, blue, etc. no longer exist according to Tailwind.)

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)