### PR TITLE
Refactor `Users::PaywalledComponent` to remove business logic

### DIFF
--- a/app/components/developers/query_component.html.erb
+++ b/app/components/developers/query_component.html.erb
@@ -4,7 +4,7 @@
   <%= form_with url: developers_path, id: form_id, method: :get do |form| %>
     <div class="pb-6">
       <%= form.label :search_query, t(".search_query_label"), class: "block text-sm font-medium text-gray-700" %>
-      <%= render Users::PaywalledComponent.new(user: user, paywalled: nil, size: :small, title: t(".paywalled_search.title")) do %>
+      <%= render Users::PaywalledComponent.new(user, nil, size: :small, title: t(".paywalled_search.title")) do %>
         <div class="mt-1 relative flex items-center">
           <%= form.text_field :search_query, value: search_query, placeholder: t(".search_query_placeholder"), class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full pr-12 sm:text-sm border-gray-300 rounded-md mt-2" %>
         </div>

--- a/app/components/developers/query_mobile_component.html.erb
+++ b/app/components/developers/query_mobile_component.html.erb
@@ -13,7 +13,7 @@
 
         <div class="mx-4 pb-4">
           <%= form.label :search_query, t("developers.query_component.search_query_label"), class: "block text-sm font-medium text-gray-700" %>
-          <%= render Users::PaywalledComponent.new(user: user, paywalled: nil, size: :small, title: t("developers.query_component.paywalled_search.title")) do %>
+          <%= render Users::PaywalledComponent.new(user, nil, size: :small, title: t("developers.query_component.paywalled_search.title")) do %>
               <%= form.text_field :search_query, value: search_query, placeholder: t("developers.query_component.search_query_placeholder"), class: "shadow-sm focus:ring-gray-500 focus:border-gray-500 block w-full sm:text-sm border-gray-300 rounded-md" %>
           <% end %>
         </div>

--- a/app/components/users/paywalled_component.rb
+++ b/app/components/users/paywalled_component.rb
@@ -40,7 +40,7 @@ module Users
     end
 
     def valid_public_profile_access?
-      @paywalled&.valid_public_profile_access?(@paywalled, @public_key)
+      @paywalled&.valid_public_profile_access?(@public_key)
     end
   end
 end

--- a/app/components/users/paywalled_component.rb
+++ b/app/components/users/paywalled_component.rb
@@ -1,8 +1,10 @@
 module Users
   class PaywalledComponent < ApplicationComponent
-    def initialize(user:, paywalled:, size: nil, title: nil, description: nil, public_key: nil)
+    private attr_reader :user, :resource, :public_key
+
+    def initialize(user, resource, size: nil, title: nil, description: nil, public_key: nil)
       @user = user
-      @paywalled = paywalled
+      @resource = resource
       @size = size
       @title = title
       @description = description
@@ -10,7 +12,7 @@ module Users
     end
 
     def render_content?
-      customer? || owner? || valid_public_profile_access?
+      Users::Permission.new(user, resource, public_key:).authorized?
     end
 
     def small?
@@ -27,20 +29,6 @@ module Users
 
     def description
       @description || t(".description")
-    end
-
-    private
-
-    def customer?
-      @user&.permissions&.active_subscription?
-    end
-
-    def owner?
-      @paywalled&.user == @user && @user.present?
-    end
-
-    def valid_public_profile_access?
-      @paywalled&.valid_public_profile_access?(@public_key)
     end
   end
 end

--- a/app/models/concerns/public_profile.rb
+++ b/app/models/concerns/public_profile.rb
@@ -10,8 +10,8 @@ module PublicProfile
     developer_public_url(self, public_profile_key)
   end
 
-  def valid_public_profile_access?(resource, profile_key)
-    resource&.public_profile_key.present? && resource.public_profile_key == profile_key
+  def valid_public_profile_access?(profile_key)
+    public_profile_key.present? && public_profile_key == profile_key
   end
 
   private

--- a/app/models/users/permission.rb
+++ b/app/models/users/permission.rb
@@ -1,0 +1,29 @@
+module Users
+  class Permission
+    private attr_reader :user, :resource, :public_key
+
+    def initialize(user, resource, public_key: nil)
+      @user = user
+      @resource = resource
+      @public_key = public_key
+    end
+
+    def authorized?
+      customer? || owner? || public_access?
+    end
+
+    private
+
+    def customer?
+      user&.permissions&.active_subscription?
+    end
+
+    def owner?
+      user.present? && resource&.user == user
+    end
+
+    def public_access?
+      resource&.valid_public_profile_access?(public_key)
+    end
+  end
+end

--- a/app/views/developers/_details.html.erb
+++ b/app/views/developers/_details.html.erb
@@ -15,7 +15,7 @@
     <%= render RoleLevels::Component.new(developer.role_level) %>
   <% end %>
 
-  <%= render Users::PaywalledComponent.new(user: current_user, paywalled: developer, size: :large, public_key:) do %>
+  <%= render Users::PaywalledComponent.new(current_user, developer, size: :large, public_key:) do %>
     <%= render RenderableComponent.new("space-y-3 pt-4") do %>
       <%= render ExternalLinkComponent.new(developer.website) %>
       <%= render SocialLinkComponent.new(developer.github, :github) %>

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -17,7 +17,7 @@
             <div class="md:flex md:items-start md:justify-between md:space-x-4 lg:border-b lg:pb-6">
               <div class="w-full">
                 <h1 class="text-2xl font-bold text-gray-900"><%= @developer.hero %></h1>
-                <%= render Users::PaywalledComponent.new(user: current_user, paywalled: @developer, size: :small, public_key: @public_key) do %>
+                <%= render Users::PaywalledComponent.new(current_user, @developer, size: :small, public_key: @public_key) do %>
                   <div class="mt-2 flex items-center text-sm font-medium text-gray-500">
                     <%= inline_svg_tag "icons/solid/user.svg", class: "flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400", aria_hidden: true %>
                     <%= @developer.name %>

--- a/test/components/users/paywalled_component_test.rb
+++ b/test/components/users/paywalled_component_test.rb
@@ -2,70 +2,41 @@ require "test_helper"
 
 module Users
   class PaywalledComponentTest < ViewComponent::TestCase
-    test "should restrict paywall content" do
-      user = users(:business)
-      developer = developers(:one)
-
-      render_inline(PaywalledComponent.new(user:, paywalled: developer)) { "Test text" }
-      assert_no_text "Test text"
-
-      render_inline(PaywalledComponent.new(user: nil, paywalled: developer)) { "Test text" }
-      assert_no_text "Test text"
-
-      render_inline(PaywalledComponent.new(user: nil, paywalled: nil)) { "Test text" }
-      assert_no_text "Test text"
+    setup do
+      @user = users(:business)
+      @resource = developers(:one)
+      @content = "Paywalled content"
     end
 
-    test "should show paywall content to customers" do
+    test "restricts paywalled content" do
+      render_inline(PaywalledComponent.new(@user, @resource)) { @content }
+      assert_no_text @content
+    end
+
+    test "shows paywalled content when authorized" do
       user = users(:subscribed_business)
-      developer = developers(:one)
-      render_inline(PaywalledComponent.new(user:, paywalled: developer)) { "Test text" }
-
-      assert_text "Test text"
+      render_inline(PaywalledComponent.new(user, @resource)) { @content }
+      assert_text @content
     end
 
-    test "should show paywall content to the owner" do
-      user = users(:developer)
-      developer = developers(:one)
-      render_inline(PaywalledComponent.new(user:, paywalled: developer)) { "Test text" }
-
-      assert_text "Test text"
+    test "shows paywalled content with a valid public profile keys" do
+      public_key = @resource.public_profile_key
+      render_inline(PaywalledComponent.new(nil, @resource, public_key:)) { @content }
+      assert_text @content
     end
 
-    test "should show small CTA if paywalled" do
-      user = users(:business)
-      developer = developers(:one)
+    test "shows a small CTA" do
+      render_inline(PaywalledComponent.new(@user, @resource, size: :small)) { @content }
 
-      render_inline(PaywalledComponent.new(user:, paywalled: developer, size: :small)) { "Test text" }
       assert_text I18n.t("users.paywalled_component.title")
       assert_no_text I18n.t("users.paywalled_component.description")
     end
 
-    test "should show large CTA if paywalled" do
-      user = users(:business)
-      developer = developers(:one)
+    test "shows a large CTA" do
+      render_inline(PaywalledComponent.new(@user, @resource, size: :large)) { @content }
 
-      render_inline(PaywalledComponent.new(user:, paywalled: developer, size: :large)) { "Test text" }
       assert_text I18n.t("users.paywalled_component.title")
       assert_text I18n.t("users.paywalled_component.description")
-    end
-
-    test "should show paywall content if valid profile access key" do
-      user = users(:business)
-      developer = developers(:one)
-      developer.share_url
-      render_inline(PaywalledComponent.new(user:, paywalled: developer, size: :large, public_key: developer.public_profile_key)) { "Test text" }
-      assert_text "Test text"
-    end
-
-    test "should show small CTA if profile access key does not match" do
-      user = users(:business)
-      developer = developers(:one)
-      developer.share_url
-      render_inline(PaywalledComponent.new(user:, paywalled: developer, size: :large, public_key: "randomkey")) { "Test text" }
-      assert_text I18n.t("users.paywalled_component.title")
-      assert_text I18n.t("users.paywalled_component.description")
-      assert_no_text "Test text"
     end
   end
 end

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -5,6 +5,7 @@ one:
   hero: Developer number one
   bio: I am the first developer.
   search_status: actively_looking
+  public_profile_key: abc123
 
 prospect:
   user: prospect_developer

--- a/test/models/concerns/public_profile_test.rb
+++ b/test/models/concerns/public_profile_test.rb
@@ -15,11 +15,11 @@ class PublicProfileTest < ActiveSupport::TestCase
   test "Should return true if valid public profile key" do
     public_profile_key = SecureRandom.hex(4)
     @developer.update!(public_profile_key: public_profile_key)
-    assert @developer.valid_public_profile_access?(@developer, public_profile_key)
+    assert @developer.valid_public_profile_access?(public_profile_key)
   end
 
   test "Should return false if public profile key does not match" do
     public_profile_key = SecureRandom.hex(4)
-    refute @developer.valid_public_profile_access?(@developer, public_profile_key)
+    refute @developer.valid_public_profile_access?(public_profile_key)
   end
 end

--- a/test/models/users/permission_test.rb
+++ b/test/models/users/permission_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+module Users
+  class PermissionTest < ActiveSupport::TestCase
+    test "authorized with an active subscription" do
+      user = users(:subscribed_business)
+      resource = developers(:one)
+
+      assert Permission.new(user, resource).authorized?
+    end
+
+    test "authorized when the owner of the resource" do
+      user = users(:developer)
+      resource = developers(:one)
+
+      assert Permission.new(user, resource).authorized?
+    end
+
+    test "authorized when the public key is valid" do
+      user = users(:empty)
+      resource = developers(:one)
+      public_key = resource.public_profile_key
+
+      assert Permission.new(user, resource, public_key:).authorized?
+    end
+
+    test "unauthorized when the public key is invalid" do
+      user = users(:empty)
+      resource = developers(:one)
+      public_key = "invalid-key"
+
+      refute Permission.new(user, resource, public_key:).authorized?
+    end
+
+    test "always unauthorized with no user" do
+      resource = developers(:one)
+
+      refute Permission.new(nil, resource).authorized?
+    end
+
+    test "always unauthorized with no resource" do
+      user = users(:empty)
+
+      refute Permission.new(user, nil).authorized?
+    end
+
+    test "always unauthorized with no user nor resource" do
+      refute Permission.new(nil, nil).authorized?
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the business + authorization logic from `Users::PaywalledComponent` into `Users::Permission`. This now more closely mimics `Businesses::Permission`, too.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~