### PR TITLE
Don't track `/developers/:id/:code` to Fathom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### October
 
+* October 21 - Option to ignore pages from being tracked in Fathom #706
 * October 20 - Upgrade Tailwind CSS to v3.2 #700
 * October 19 - Upgrade to Turbo 7.2.2 #683 @sarvaiyanidhi
 * October 12 - Remove manual payments and account for payments made via ACH #681

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,6 +1,6 @@
 module AnalyticsHelper
   def analytics_tag
     site_id = Rails.configuration.fathom
-    javascript_include_tag "https://cdn.usefathom.com/script.js", defer: true, data: {site: site_id}
+    javascript_include_tag "https://cdn.usefathom.com/script.js", defer: true, data: {site: site_id, auto: false}
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,6 @@
 // Entry point for the build script in your package.json
 import "./controllers"
 import "./src/clipboard"
-import "./src/fathom"
 import "./src/turbo_native/bridge"
 import "@hotwired/turbo-rails"
 import * as ActiveStorage from "@rails/activestorage"

--- a/app/javascript/controllers/analytics/page_views_controller.js
+++ b/app/javascript/controllers/analytics/page_views_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    document.addEventListener("turbo:load", this.trackPageView.bind(this), {once: true})
+  }
+
+  trackPageView() {
+    if (window.fathom && this.shouldTrackPageView) {
+      window.fathom.trackPageview()
+    }
+  }
+
+  // Add `<meta id="ignorePageview">` to the DOM to *not* track a page view to Fathom.
+  get shouldTrackPageView() {
+    return !document.querySelector("#ignorePageView")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,6 +9,9 @@ application.register("accessibility", AccessibilityController)
 import Analytics__EventsController from "./analytics/events_controller.js"
 application.register("analytics--events", Analytics__EventsController)
 
+import Analytics__PageViewsController from "./analytics/page_views_controller.js"
+application.register("analytics--page-views", Analytics__PageViewsController)
+
 import ClipboardController from "./clipboard_controller.js"
 application.register("clipboard", ClipboardController)
 

--- a/app/javascript/src/fathom.js
+++ b/app/javascript/src/fathom.js
@@ -1,5 +1,0 @@
-document.addEventListener("turbo:load", function() {
-  if (window.fathom) {
-    window.fathom.trackPageview()
-  }
-})

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -1,5 +1,7 @@
 <%= open_graph_tags component: Developers::OpenGraphTagsComponent, developer: @developer %>
 
+<%= tag.meta id: "ignorePageView" if @public_key.present? %>
+
 <div class="max-w-5xl mx-auto mt-0 lg:mt-16 pb-8 mb-16 bg-white shadow lg:rounded-lg overflow-hidden">
   <%= render Developers::CoverImageComponent.new(developer: @developer, classes: "lg:rounded-t-lg") %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= hotwire_livereload_tags %>
   </head>
 
-  <body class="min-h-full flex flex-col">
+  <body data-controller="analytics--page-views" class="min-h-full flex flex-col">
     <div class="flex-1">
       <%= render ImpersonatingBannerComponent.new %>
       <%= render NavBar::BaseComponent.new(current_user) %>

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -66,6 +66,16 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "viewing a profile with a public key (valid or not) doesn't get tracked" do
+    developer = developers(:one)
+
+    get developer_path(developer)
+    assert_select "#ignorePageView", count: 0
+
+    get developer_path(developer, key: "some-key")
+    assert_select "#ignorePageView"
+  end
+
   test "developers are sorted newest first" do
     create_developer(hero: "Oldest")
     create_developer(hero: "Newest")


### PR DESCRIPTION
This PR turns off automatic page view tracking via Fathom. Manual tracking replaces it by calling `fathom.trackPageView()`. Private pages, like developer profile's with the public code, are ignored so they don't show up in the public analytics dashboard. To ignore a page from being tracked add the following to the DOM.

```html
<meta id="ignorePageview">
```

Closes #699.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)