### PR TITLE
Fix tailwind postcss setup #709

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,8 +1,6 @@
-@config "./../../../tailwind.config.js";
-
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
-@import "tailwindcss/overrides";
+@import "./tailwindcss/overrides.css";
 
-@import "components/pagy";
+@import "./components/pagy.css";

--- a/app/assets/stylesheets/redesign.tailwind.css
+++ b/app/assets/stylesheets/redesign.tailwind.css
@@ -1,8 +1,6 @@
-@config "./../../../redesign.config.js";
-
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
-@import "tailwindcss/overrides";
+@import "./tailwindcss/overrides.css";
 
-@import "components/pagy";
+@import "./components/pagy.css";

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
-    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css",
-    "build:redesign": "tailwindcss -i ./app/assets/stylesheets/redesign.tailwind.css -o ./app/assets/builds/redesign.css"
+    "build:css": "tailwindcss --postcss -c tailwind.config.js -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css",
+    "build:redesign": "tailwindcss --postcss -c redesign.config.js -i ./app/assets/stylesheets/redesign.tailwind.css -o ./app/assets/builds/redesign.css"
   }
 }

--- a/redesign.config.js
+++ b/redesign.config.js
@@ -60,6 +60,7 @@ module.exports = {
     },
     fontSize: {
       "xs": ["12px", "18px"],
+      "sm": ["14px", "21px"],
       "base": ["16px", "24px"],
       "xl": ["20px", "30px"],
       "2xl": ["24px", "36px"],


### PR DESCRIPTION
The `--postcss` parameter tells the Tailwind CLI to use our custom Postcss configuration.

The new `@config` directive doesn't work for some reason. However, specifying the config file directly as a CLI parameter seems to work.

I've also added the missing `text-sm` to the `redesign.config.js`, it's used by Pagy.

Fixes #709