### PR TITLE
Set request variant for redesign requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   around_action :set_locale
+  before_action :set_variant
+
   helper_method :resolve_locale
   helper_method :turbo_native_app?
 
@@ -28,5 +30,11 @@ class ApplicationController < ActionController::Base
     redirect_back_or_to root_path, allow_other_host: false
   rescue ActionController::Redirecting::UnsafeRedirectError
     redirect_to root_path
+  end
+
+  def set_variant
+    if Feature.enabled?(:redesign)
+      request.variant = :redesign
+    end
   end
 end


### PR DESCRIPTION
When the `:redesign` feature flag is enabled, views with `+redesign` will be rendered. For example, for the home page:

* Rendered when enabled: `app/views/home/show.html+redesign.erb` 
* *Otherwise: `app/views/home/show.html.erb`

If no `+redesign` variant is present then the non-variant (default) version will be rendered.