### PR TITLE
Github Actions changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
   push:
-    branches: [ main ]
+    branches: [main]
 
 concurrency: ci-${{ github.ref }}
 
@@ -18,7 +18,7 @@ jobs:
     services:
       postgres:
         image: postgres:13
-        ports: [ "5432:5432" ]
+        ports: ["5432:5432"]
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -30,8 +30,7 @@ jobs:
 
       redis:
         image: redis
-        ports:
-          - "6379:6379"
+        ports: ["6379:6379"]
 
     steps:
       - name: Checkout Commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,59 +2,23 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - "*"
+    branches: [ "*" ]
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 concurrency: ci-${{ github.ref }}
 
 jobs:
-  install-cache:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    strategy:
-      matrix:
-        node-version: [14]
-    steps:
-      - name: Checkout Commit
-        uses: actions/checkout@v2
-
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Cache yarn dependencies
-        uses: actions/cache@v2
-        id: cache-dependencies
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install yarn dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: |
-          yarn install --force --non-interactive
-
   test:
+    name: Test
+
     runs-on: ubuntu-latest
-    needs: install-cache
     timeout-minutes: 10
 
     services:
-      db:
-        image: postgres:12.10
-        ports: ["5432:5432"]
+      postgres:
+        image: postgres:13
+        ports: [ "5432:5432" ]
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -71,31 +35,35 @@ jobs:
 
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get install -yqq libvips
-
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
 
-      - name: Restore yarn dependencies
-        uses: actions/cache@v2
+      - name: Cache yarn dependencies
+        uses: actions/cache@v3
         id: cache-dependencies
         with:
           path: node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Install yarn dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: yarn install --force --non-interactive --frozen-lockfile
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -yqq libvips
 
       - name: Standardize
         run: bundle exec standardrb
@@ -106,6 +74,21 @@ jobs:
       - name: i18n-tasks
         run: bundle exec i18n-tasks health en
 
+      - name: Build assets
+        run: |
+          bin/rails javascript:build
+          bin/rails css:build
+
+      - name: Prepare database
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:password@localhost:5432/railsdevs_test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          TZ: America/New_York
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
       - name: Run tests
         env:
           RAILS_ENV: test
@@ -113,10 +96,6 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           TZ: America/New_York
         run: |
-          bin/rails javascript:build
-          bin/rails css:build
-          bin/rails db:create
-          bin/rails db:schema:load
           bin/rails test --fail-fast
           bin/rails test:system
 
@@ -126,7 +105,7 @@ jobs:
           DATABASE_URL: postgres://postgres:password@localhost:5432/railsdevs_test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           TZ: America/New_York
-        run: bundle exec rails db:reset
+        run: bin/rails db:reset
 
       - name: Verify mailer previews
         env:
@@ -134,4 +113,4 @@ jobs:
           DATABASE_URL: postgres://postgres:password@localhost:5432/railsdevs_test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           TZ: America/New_York
-        run: bundle exec rake verify_mailer_previews
+        run: bin/rails verify_mailer_previews

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,24 +1,13 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '26 21 * * 0'
+    - cron: "26 21 * * 0"
 
 jobs:
   analyze:
@@ -32,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'ruby' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        language: ["javascript", "ruby"]
+        # CodeQL supports ["cpp", "csharp", "go", "java", "javascript", "python", "ruby"]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:


### PR DESCRIPTION
Changes in this PR:

- Removed the unnecessary `strategy.matrix` because there was only one node version specified.
- Updated versions of some older actions (`checkout`, `cache`, `setup-node`, `codeql-action`).
- Updated `node` to `16` to match the version in the `.node-version` file.
- Updated `postgres` to `13` because this version is mentioned in the `README` file. If you are using something else in production, let me know.
- Added the argument `--frozen-lockfile` to the `yarn install` ([docs](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile)).
- Split the `Run tests` step into multiple smaller steps (`Build assets`, `Prepare database`, `Run tests`).
- Joined the two jobs into one because they were not running in parallel anyway. This should remove some overhead.

If there was any reason for the previous state and/or you want to keep it as it was (e.g. two jobs), just let me know.