### PR TITLE
Don't touch `updated_at` when setting `developers.source_contributor`

### DIFF
--- a/app/controllers/admin/developers/source_contributors_controller.rb
+++ b/app/controllers/admin/developers/source_contributors_controller.rb
@@ -2,13 +2,21 @@ module Admin
   module Developers
     class SourceContributorsController < ApplicationController
       def create
-        Developer.find(params[:developer_id]).update(source_contributor: true)
+        set_developer_source_contributor(true)
         redirect_back_or_to root_path, allow_other_host: false
       end
 
       def destroy
-        Developer.find(params[:developer_id]).update(source_contributor: false)
+        set_developer_source_contributor(false)
         redirect_back_or_to root_path, allow_other_host: false
+      end
+
+      private
+
+      def set_developer_source_contributor(source_contributor)
+        developer = Developer.find(params[:developer_id])
+        developer.source_contributor = source_contributor
+        developer.save!(touch: false)
       end
     end
   end

--- a/test/integration/admin/developers/source_contributors_test.rb
+++ b/test/integration/admin/developers/source_contributors_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Admin::Developers::SourceContributorsTest < ActionDispatch::IntegrationTest
+  test "activates a source contributor" do
+    developer = developers(:one)
+    sign_in users(:admin)
+
+    post admin_developer_source_contributors_path(developer)
+
+    assert developer.reload.source_contributor?
+  end
+
+  test "deactivates a source contributor" do
+    developer = developers(:one)
+    developer.update!(source_contributor: true)
+    sign_in users(:admin)
+
+    delete admin_developer_source_contributors_path(developer)
+
+    refute developer.reload.source_contributor?
+  end
+
+  test "neither update the updated_at column" do
+    developer = developers(:one)
+    sign_in users(:admin)
+
+    assert_no_changes "developer.reload.updated_at" do
+      post admin_developer_source_contributors_path(developer)
+      delete admin_developer_source_contributors_path(developer)
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that changing the "source contributor" status on a developer doesn't update their `updated_at` column. This is to avoid accidentally setting the "Recently active" badge.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~