### PR TITLE
Save referral code when signing up for 30 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### November
 
+* November 23 - Save referral code when creating an account #730
 * November 8 - Do not add hrefs for transaction without urls #722 @kaushikhande
 * November 3 - Publicly shareable URLs via modal #647 @sarvaiyanidhi
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   include HoneybadgerUserContext
   include Locales
   include Pundit::Authorization
+  include Referrals
   include StoredLocation
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/app/controllers/concerns/referrals.rb
+++ b/app/controllers/concerns/referrals.rb
@@ -1,0 +1,19 @@
+module Referrals
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_ref_cookie
+  end
+
+  def set_ref_cookie
+    if params[:ref].present?
+      cookies[:ref] = {value: params[:ref], expires: 30.days}
+    end
+  end
+
+  def create_referral(user)
+    if cookies[:ref].present?
+      user.create_referral!(code: cookies[:ref])
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,11 @@
 class UsersController < Devise::RegistrationsController
+  include Referrals
+
   invisible_captcha only: :create
+
+  def create
+    super do |user|
+      create_referral(user) if user.valid?
+    end
+  end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -24,6 +24,7 @@ class Developer < ApplicationRecord
   belongs_to :user
   has_many :conversations, -> { visible }
   has_many :messages, -> { where(sender_type: Developer.name) }, through: :conversations
+  has_many :hired_forms, class_name: "Hired::Form", dependent: :destroy
   has_one :location, dependent: :destroy, autosave: true
   has_one :role_level, dependent: :destroy, autosave: true
   has_one :role_type, dependent: :destroy, autosave: true

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -1,0 +1,5 @@
+class Referral < ApplicationRecord
+  belongs_to :user
+
+  validates :code, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :notifications, as: :recipient, dependent: :destroy
   has_one :business, dependent: :destroy
   has_one :developer, dependent: :destroy
+  has_one :referral, dependent: :destroy
 
   has_many :conversations, ->(user) {
     unscope(where: :user_id)

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,3 @@
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+end

--- a/db/migrate/20221124025600_create_referrals.rb
+++ b/db/migrate/20221124025600_create_referrals.rb
@@ -1,0 +1,10 @@
+class CreateReferrals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :referrals do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+      t.string :code, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_07_145250) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_24_025600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -349,6 +349,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_145250) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "referrals", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_referrals_on_user_id"
+  end
+
   create_table "role_levels", force: :cascade do |t|
     t.bigint "developer_id"
     t.boolean "junior"
@@ -401,6 +409,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_145250) do
   add_foreign_key "pay_charges", "pay_subscriptions", column: "subscription_id"
   add_foreign_key "pay_payment_methods", "pay_customers", column: "customer_id"
   add_foreign_key "pay_subscriptions", "pay_customers", column: "customer_id"
+  add_foreign_key "referrals", "users"
   add_foreign_key "role_levels", "developers"
   add_foreign_key "role_types", "developers"
 end

--- a/test/integration/referrals_test.rb
+++ b/test/integration/referrals_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ReferralsTest < ActionDispatch::IntegrationTest
+  test "the ref param is set to a cookie" do
+    assert_nil cookies[:ref]
+    get root_path(ref: "abc123")
+    assert_equal "abc123", cookies[:ref]
+  end
+
+  test "no ref param doesn't clear existing cookies" do
+    cookies[:ref] = "existing"
+    get root_path(ref: "")
+    assert_equal "existing", cookies[:ref]
+  end
+
+  test "new ref params overwrite existing cookies" do
+    cookies[:ref] = "existing"
+    get root_path(ref: "new")
+    assert_equal "new", cookies[:ref]
+  end
+end

--- a/test/integration/users_test.rb
+++ b/test/integration/users_test.rb
@@ -20,4 +20,41 @@ class UsersTest < ActionDispatch::IntegrationTest
     get new_user_session_path
     assert_redirected_to new_role_path
   end
+
+  test "creating an account persists the referral code" do
+    get root_path(ref: "ref-code")
+    user = register_new_user
+    assert_equal "ref-code", user.referral.code
+  end
+
+  test "invalid account creation doesn't persist referral code" do
+    get root_path(ref: "ref-code")
+
+    assert_no_changes "User.count" do
+      post user_registration_path(user: {
+        email: users(:empty).email
+      })
+    end
+
+    assert_nil users(:empty).referral
+  end
+
+  test "doesn't persist a referral if not referred" do
+    user = register_new_user
+    assert_nil user.referral
+  end
+
+  def register_new_user
+    assert_changes "User.count", 1 do
+      post user_registration_path(user: {
+        email: "referred@example.com",
+        password: "password",
+        password_confirmation: "password"
+      })
+    end
+
+    user = User.find_by(email: "referred@example.com")
+    user.confirm
+    user
+  end
 end


### PR DESCRIPTION
This PR sets a 30 day cookie when the `ref` URL param is present. When signing up, this is saved to `Referral` model which a `User` has one of.

Closes #727.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)