### PR TITLE
fix: issue with incorrect role level query param

### DIFF
--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -45,13 +45,13 @@ class Developer < ApplicationRecord
   scope :filter_by_role_types, ->(role_types) do
     RoleType::TYPES.filter_map { |type|
       where(role_type: {type => true}) if role_types.include?(type)
-    }.reduce(:or).joins(:role_type)
+    }.reduce(:or)&.joins(:role_type)
   end
 
   scope :filter_by_role_levels, ->(role_levels) do
     RoleLevel::TYPES.filter_map { |level|
       where(role_level: {level => true}) if role_levels.include?(level)
-    }.reduce(:or).joins(:role_level)
+    }.reduce(:or)&.joins(:role_level)
   end
 
   scope :filter_by_utc_offsets, ->(utc_offsets) do

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -77,6 +77,12 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_select "h2", "Part-time"
   end
 
+  test "developers with incorrect role type query does not raise an error" do
+    assert_nothing_raised do
+      get developers_path(role_types: ["foo"])
+    end
+  end
+
   test "developers can be filtered by role level" do
     create_developer(hero: "Mid", role_level_attributes: {mid: true})
 


### PR DESCRIPTION
Fix issue where the query parameter is incorrect, the query parameter was `mid'` instead of `mid` (not sure how that happened through the UI, maybe it was typed in)

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

Closes #738 
