### PR TITLE
Redirect suspended accounts to `/users/suspended`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### January
 
+* January 26 - Redirect suspended accounts
 * January 24 - Revamp CTA design with blurred out developers #743 @izaguirrejoe
 * January 1 - Hiring agreement announcement email #749
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   around_action :set_locale
+  before_action :redirect_suspended_accounts
   before_action :set_variant
 
   helper_method :resolve_locale
@@ -31,6 +32,12 @@ class ApplicationController < ActionController::Base
     redirect_back_or_to root_path, allow_other_host: false
   rescue ActionController::Redirecting::UnsafeRedirectError
     redirect_to root_path
+  end
+
+  def redirect_suspended_accounts
+    if current_user&.suspended?
+      redirect_to users_suspended_path
+    end
   end
 
   def set_variant

--- a/app/controllers/hiring_agreements/terms_controller.rb
+++ b/app/controllers/hiring_agreements/terms_controller.rb
@@ -1,6 +1,7 @@
 module HiringAgreements
   class TermsController < ApplicationController
     before_action :require_active_hiring_agreement!
+    skip_before_action :redirect_suspended_accounts
 
     def show
       @term = Term.active

--- a/app/controllers/users/suspended_controller.rb
+++ b/app/controllers/users/suspended_controller.rb
@@ -1,0 +1,8 @@
+module Users
+  class SuspendedController < ApplicationController
+    skip_before_action :redirect_suspended_accounts
+
+    def show
+    end
+  end
+end

--- a/app/views/users/suspended/show.html.erb
+++ b/app/views/users/suspended/show.html.erb
@@ -1,0 +1,12 @@
+<div class="py-24 px-6 sm:px-6 sm:py-32 lg:px-8">
+  <div class="mx-auto max-w-2xl text-center">
+    <h2 class="text-4xl font-bold tracking-tight text-gray-900"><%= t(".title") %></h2>
+    <p class="mx-auto mt-6 max-w-xl text-lg leading-7 text-gray-600"><%= t(".description") %></p>
+    <div class="mt-10 flex items-center justify-center gap-x-6">
+      <%= link_to t(".cta"), "mailto:#{Rails.configuration.emails.support}", class: "rounded-md bg-gray-600 px-3.5 py-1.5 text-base font-semibold leading-7 text-white shadow-sm hover:bg-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-600" %>
+      <%= link_to hiring_agreement_terms_path, class: "text-base font-semibold leading-7 text-gray-900" do %>
+        <%= t(".learn_more") %> <span aria-hidden="true">→</span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -718,6 +718,12 @@ en:
     paywalled_component:
       description: Information that is only visible with a business subscription.
       title: Private information
+    suspended:
+      show:
+        cta: Email Joe
+        description: Failure to comply with the hiring agreement has forced RailsDevs to suspend your account. Contact Joe to pay your obligated hiring fees and resume your account.
+        learn_more: Learn more
+        title: Your account has been suspended.
   utc_offsets:
     component:
       gmt: GMT

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Rails.application.routes.draw do
       resource :terms, only: :show
     end
 
+    namespace :users do
+      resource :suspended, only: :show, controller: :suspended
+    end
+
     root to: "home#show"
   end
 

--- a/db/migrate/20230126221401_add_suspended_to_user.rb
+++ b/db/migrate/20230126221401_add_suspended_to_user.rb
@@ -1,0 +1,5 @@
+class AddSuspendedToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :suspended, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_26_042109) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_221401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -401,6 +401,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_26_042109) do
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
     t.string "authentication_token"
+    t.boolean "suspended", default: false, null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds/businesses.rb
+++ b/db/seeds/businesses.rb
@@ -22,3 +22,7 @@ SeedsHelper.create_business!("lead")
 # Invisible business
 business = SeedsHelper.create_business!("invisible")
 business.invisiblize_and_notify! if business.visible?
+
+# Suspended business
+business = SeedsHelper.create_business!("suspended")
+business.user.update!(suspended: true) unless business.user.suspended?

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -27,6 +27,12 @@ subscribed_business:
   confirmed_at: <%= DateTime.current %>
   authentication_token: <%= Devise.friendly_token %>
 
+suspended:
+  email: suspended@example.com
+  suspended: true
+  confirmed_at: <%= DateTime.current %>
+  authentication_token: <%= Devise.friendly_token %>
+
 admin:
   email: admin@example.com
   confirmed_at: <%= DateTime.current %>

--- a/test/integration/suspended_accounts_test.rb
+++ b/test/integration/suspended_accounts_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class SuspendedAccountsTest < ActionDispatch::IntegrationTest
+  test "non-suspended accounts can visit the site" do
+    get developers_path
+    assert_response :ok
+
+    sign_in users(:business)
+    get developers_path
+    assert_response :ok
+  end
+
+  test "suspended accounts are redirected" do
+    sign_in users(:suspended)
+    get developers_path
+    assert_redirected_to users_suspended_path
+    follow_redirect!
+  end
+
+  test "suspended accounts can view the hiring agreement" do
+    sign_in users(:suspended)
+    get hiring_agreement_terms_path
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
Welp, it finally happened. I have to suspend an account because they've hired _two_ developers via RailsDevs but refuse to pay the hiring fee. ...sigh.

Set `users.suspended` to true from the console to a suspend an account.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)