### PR TITLE
Add tooltip with html title to headers on the admin conversations das…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 2023
 
 ### March
+
 * March 8 - Add a tooltip to replied and email headers on the admin conversations dashboard #796 @franlocus
 * March 7 - Automate subscriber welcome email #794 @duncantmiller
 * March 3 - Upgrade Devise to v4.9.0 to support hotwire turbo integration #786 @sarvaiyanidhi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 2023
 
 ### March
-
+* March 8 - Add a tooltip to replied and email headers on the admin conversations dashboard #796 @franlocus
 * March 7 - Automate subscriber welcome email #794 @duncantmiller
 * March 3 - Upgrade Devise to v4.9.0 to support hotwire turbo integration #786 @sarvaiyanidhi
 * March 1 - Add a badge for developers with a high response rate #774 @fig

--- a/app/components/admin/tables/header_component.rb
+++ b/app/components/admin/tables/header_component.rb
@@ -3,16 +3,18 @@ module Admin
     class HeaderComponent < ApplicationComponent
       include CellAlignment
 
-      attr_reader :title, :align
+      attr_reader :title, :tooltip, :align
 
-      def initialize(title = nil, align: :left)
+      def initialize(title = nil, tooltip = nil, align: :left)
         @title = title
+        @tooltip = tooltip
         @align = align
       end
 
       def call
         tag.th title || content, scope: "col",
-          class: class_names("px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider", align_class)
+          class: class_names("px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider", align_class),
+          title: tooltip
       end
     end
   end

--- a/app/components/admin/tables/header_component.rb
+++ b/app/components/admin/tables/header_component.rb
@@ -12,9 +12,8 @@ module Admin
       end
 
       def call
-        tag.th title || content, scope: "col",
-          class: class_names("px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider", align_class),
-          title: tooltip
+        tag.th title || content, scope: "col", title: tooltip,
+          class: class_names("px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider", align_class)
       end
     end
   end

--- a/app/views/admin/conversations/index.html.erb
+++ b/app/views/admin/conversations/index.html.erb
@@ -19,8 +19,8 @@
       <% table.with_header t(".business") %>
       <% table.with_header t(".developer") %>
       <% table.with_header t(".started") %>
-      <% table.with_header "#{t(".replied")}?" %>
-      <% table.with_header "#{t(".email")}?" %>
+      <% table.with_header "#{t(".replied")}?", "#{t(".replied_tooltip")}" %>
+      <% table.with_header "#{t(".email")}?", "#{t(".email_tooltip")}" %>
       <% table.with_header do %>
         <span class="sr-only"><%= t(".view") %></span>
       <% end %>

--- a/app/views/admin/conversations/index.html.erb
+++ b/app/views/admin/conversations/index.html.erb
@@ -19,8 +19,8 @@
       <% table.with_header t(".business") %>
       <% table.with_header t(".developer") %>
       <% table.with_header t(".started") %>
-      <% table.with_header "#{t(".replied")}?", "#{t(".replied_tooltip")}" %>
-      <% table.with_header "#{t(".email")}?", "#{t(".email_tooltip")}" %>
+      <% table.with_header "#{t(".replied")}?", t(".replied_tooltip") %>
+      <% table.with_header "#{t(".email")}?", t(".email_tooltip") %>
       <% table.with_header do %>
         <span class="sr-only"><%= t(".view") %></span>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,10 +70,12 @@ en:
         conversations: "'s conversations"
         developer: Developer
         email: Email
+        email_tooltip: The developer mentioned an email address in a reply.
         no_potential_email: No potential email
         no_response: No response
         potential_email: Potential email
         replied: Replied
+        replied_tooltip: The developer has replied to this conversation.
         reply_rate: Reply rate
         started: Started
         title: Conversations


### PR DESCRIPTION
Hi!
According to #796 
This PR does the following;

    Add a title HTML attribute to the two headers(replied and email) explaining what they do.

The HTML title attribute appears as a tooltip when hovering the element. Use the following titles:

    REPLIED? - The developer has replied to this conversation.
    EMAIL? - The developer mentioned an email address in a reply.

Also I added i18n to EN.yml under keys: email_tooltip and replied_tooltip

What are your thoughts?

Greetings!

<!-- Description of pull request linking to any relevant issues. -->

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->



- [ ] My code contains tests covering the code I modified

-  [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
