### PR TITLE
fix typos in Spanish i18n

### DIFF
--- a/config/locales/devise.views.es.yml
+++ b/config/locales/devise.views.es.yml
@@ -17,7 +17,7 @@ es:
         locked_at: Fecha de bloqueo
         remember_created_at: Fecha de 'Recordarme'
         reset_password_sent_at: Fecha de envío de código para contraseña
-        reset_password_token: Código para reestablecer contraseña
+        reset_password_token: Código para restablecer contraseña
         sign_in_count: Cantidad de ingresos
         unconfirmed_email: Correo electrónico no confirmado
         unlock_token: Código de desbloqueo
@@ -77,10 +77,10 @@ es:
         new_password: Nueva contraseña
       new:
         forgot_your_password: "¿Ha olvidado su contraseña?"
-        send_me_reset_password_instructions: Envíeme las instrucciones para reestablecer mi contraseña
-      no_token: No puedes acceder a esta página si no es a través de un enlace para reestablecer tu contraseña. Si has llegado hasta aquí desde el correo electrónico para reestablecer tu contraseña, por favor asegúrate de que la URL introducida está completa.
-      send_instructions: Recibirás un correo con instrucciones sobre cómo resetear tu contraseña en unos pocos minutos.
-      send_paranoid_instructions: Si tu correo existe en nuestra base de datos, recibirás un correo con instrucciones sobre cómo reestablecer tu contraseña en tu bandeja de entrada.
+        send_me_reset_password_instructions: Envíeme las instrucciones para restablecer mi contraseña
+      no_token: No puedes acceder a esta página si no es a través de un enlace para restablecer tu contraseña. Si has llegado hasta aquí desde el correo electrónico para restablecer tu contraseña, por favor asegúrate de que la URL introducida está completa.
+      send_instructions: Recibirás un correo con instrucciones sobre cómo restablecer tu contraseña en unos pocos minutos.
+      send_paranoid_instructions: Si tu correo existe en nuestra base de datos, recibirás un correo con instrucciones sobre cómo restablecer tu contraseña en tu bandeja de entrada.
       updated: Se ha cambiado tu contraseña. Ya iniciaste sesión.
       updated_not_active: Tu contraseña fue cambiada.
     registrations:
@@ -88,7 +88,7 @@ es:
       edit:
         are_you_sure: "¿Está usted seguro?"
         cancel_my_account: Anular mi cuenta
-        currently_waiting_confirmation_for_email: 'Actualmente esperando la confirmacion de: %{email} '
+        currently_waiting_confirmation_for_email: 'Actualmente esperando la confirmación de: %{email} '
         leave_blank_if_you_don_t_want_to_change_it: dejar en blanco si no desea cambiarla
         title: Editar %{resource}
         unhappy: "¿Disconforme?"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,14 +119,14 @@ es:
         title: Presencia en línea
       profile:
         avatar: Avatar
-        avatar_error_text: Algó falló al subir tu imagen, por favor intenta de nuevo.
+        avatar_error_text: Algo falló al subir tu imagen, por favor intenta de nuevo.
         change: Subir
         cover_image: Imagen de portada
         help_text: Esta información será pública, así que ten cuidado con lo que compartas.
         hero_help_text: Algunas palabras que te describan como desarrollador.
         name_help_text_html: Tu nombre no va a aparecer en tu perfil público.
         title: Perfil
-        upload_error_text: Algó falló al subir tu imagen, por favor intenta de nuevo.
+        upload_error_text: Algo falló al subir tu imagen, por favor intenta de nuevo.
         upload_file: Sube un archivo
         upload_help_text: PNG, JPG, GIF hasta 10MB de tamaño
       role_level:
@@ -267,4 +267,4 @@ es:
   users:
     paywalled_component:
       description: Información que solo es visible con una suscripción comercial.
-      title: Información provada
+      title: Información privada


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->
Fix typos in Spanish, the words changed are:

- reestablecer -> restablecer
- resetear -> restablecer
- Algó -> Algo
- provada -> privada
- confirmacion -> confirmación

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
