### PR TITLE
Add Tab Ordering and AutoFocus on sign in and Registration Page

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -15,7 +15,7 @@
         <div>
           <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
           <div class="mt-1">
-            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm", autofocus: true %>
           </div>
         </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -17,7 +17,7 @@
         <div>
           <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
           <div class="mt-1">
-            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm", autofocus: true %>
           </div>
         </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
         <div>
           <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
           <div class="mt-1">
-            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm", autofocus: true %>
           </div>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,7 +15,7 @@
         <div>
           <%= form.label :email, class: "block text-sm font-medium text-gray-700" %>
           <div class="mt-1">
-            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            <%= form.email_field :email, autocomplete: "email", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm", autofocus: true, tabindex: "1" %>
           </div>
         </div>
 
@@ -26,12 +26,12 @@
           </div>
 
           <div class="mt-1">
-            <%= form.password_field :password, autocomplete: "current-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm" %>
+            <%= form.password_field :password, autocomplete: "current-password", required: true, class: "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm", tabindex: "2" %>
           </div>
         </div>
 
         <div>
-          <%= form.button t("sessions.sign_in"), class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500" %>
+          <%= form.button t("sessions.sign_in"), class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500", tabindex: "4" %>
         </div>
       <% end %>
     </div>

--- a/app/views/devise/shared/_forgot_link.html.erb
+++ b/app/views/devise/shared/_forgot_link.html.erb
@@ -1,3 +1,3 @@
 <div class="text-sm">
-  <%= link_to t("devise.passwords.new.forgot_your_password"), new_password_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500" %>
+  <%= link_to t("devise.passwords.new.forgot_your_password"), new_password_path(resource_name), class: "font-medium text-gray-600 hover:text-gray-500", tabindex: "3" %>
 </div>


### PR DESCRIPTION
This PR address:

- [x] Set the tab order on the sign in screen to email then password then forgot password
- [x] Set the tab order on the registration screen to email then password then password confirmation
- [x] Autofocus on the email field for Sign in, Registration, Forgot Password and Resend confirmation page

_Note: Tab Ordering on registration screen to email then password then password confirmation is already maintained because of its location in source code (these fields are in ascending order as per code) & hence changes are not required_

### <ins> Screen Recording of Autofocus on mentioned pages

https://user-images.githubusercontent.com/36496890/226115603-188d1edc-8aaf-4357-b4ab-5868cd8bf2a4.mov


### <ins> Screen Recording of Tab Ordering on Sign in page

https://user-images.githubusercontent.com/36496890/226115920-3445bc81-261a-48e6-b7ce-cbec1af5ba5e.mov


