### PR TITLE
Fixes record duplication in DeveloperQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### March
 
+* March 20 - Update developer query to not duplicate records with multiple matching specialties #822 @bschrag620
 * March 18 - Add developer specialties #803
 * March 16 - Don't retry emails for invalid/unsubscribed recipients #798 @zzJZzz
 * March 15 - Fix Preview image doesn't change when select new avatar in profile page #787 @ryy

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -74,6 +74,16 @@ class Developer < ApplicationRecord
   scope :newest_first, -> { order(created_at: :desc) }
   scope :profile_reminder_notifications, -> { where(profile_reminder_notifications: true) }
   scope :visible, -> { where.not(search_status: :invisible).or(where(search_status: nil)) }
+  scope :with_specialty_ids, ->(specialty_ids) {
+    where_sql = <<-SQL
+      exists (
+        select 1 from specialty_tags
+        where specialty_tags.specialty_id in (?)
+          and specialty_tags.developer_id = developers.id
+      )
+    SQL
+    where(where_sql, Array.wrap(specialty_ids))
+  }
 
   def visible?
     !invisible?

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -121,7 +121,7 @@ class DeveloperQuery
 
   def specialty_filter_records
     if specialty_ids.any?
-      @_records.merge!(Developer.left_outer_joins(:specialties).where(specialties: {id: specialty_ids}))
+      @_records.merge!(Developer.with_specialty_ids(specialty_ids))
     end
   end
 

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -181,6 +181,7 @@ class DeveloperQueryTest < ActiveSupport::TestCase
     assert_includes records, stimulus_developer
     refute_includes records, react_developer
     refute_includes records, developer
+    assert_equal records.length, records.uniq.length
   end
 
   test "filtering developers by their bio or hero does not includes all if business has an active subscription" do


### PR DESCRIPTION
I believe the current implementation of the specialty filters in `DeveloperQuery` is incorrectly returning multiple the same developer when they have multiple matches to the selected specialties. Take this from the test case as an example:
```
hotwire_developer = create_developer(specialty_ids: [turbo.id, stimulus.id])
records = DeveloperQuery.new(specialty_ids: [turbo.id, stimulus.id]).records
records.length => 2
records == [hotwire_developer, hotwire_developer] => true
```

This PR is adding a `with_specialties` scope that accepts a or many specialty ids and uses a subquery to retrieve a single record, even if the record has many matches in specialties. The specialty filter test case was extended to check for uniqueness as well.

* changes the where clause used for the specialties filter so that the same user isn't returned multiple times

<!-- Description of pull request linking to any relevant issues. -->

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
