### PR TITLE
Fix seeds after migration

### DIFF
--- a/app/jobs/update_developer_response_rate_job.rb
+++ b/app/jobs/update_developer_response_rate_job.rb
@@ -1,8 +1,6 @@
 class UpdateDeveloperResponseRateJob < ApplicationJob
   queue_as :default
 
-  GRACE_PERIOD = Rails.application.config.developer_response_grace_period
-
   def perform(developer)
     conversations = eligable_conversations(developer)
     replied_rate = Stats::Conversation.new(conversations).replied_rate
@@ -17,8 +15,11 @@ class UpdateDeveloperResponseRateJob < ApplicationJob
   private
 
   def eligable_conversations(developer)
+    grace_period = Rails.application.config.developer_response_grace_period
+    grace_period_start = grace_period.nil? ? Time.current : grace_period.ago
+
     developer.conversations.reject do |conversation|
-      conversation.created_at > GRACE_PERIOD.ago && !conversation.developer_replied?
+      conversation.created_at > grace_period_start && !conversation.developer_replied?
     end
   end
 end

--- a/app/models/concerns/messages/notifications.rb
+++ b/app/models/concerns/messages/notifications.rb
@@ -31,9 +31,8 @@ module Messages
     end
 
     def update_developer_response_rate
-      UpdateDeveloperResponseRateJob
-        .set(wait: Rails.application.config.developer_response_grace_period)
-        .perform_later(developer)
+      wait = Rails.application.config.developer_response_grace_period
+      UpdateDeveloperResponseRateJob.set(wait:).perform_later(developer)
     end
 
     def first_message?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,9 +85,9 @@ Rails.application.configure do
   # Enable local development exposed via ngrok for webhook testing.
   config.hosts << /.*\.ngrok\.io/
 
-  # Set a zero value for developer response grace period in development to allow seeding without leaving
+  # Disable developer response grace period in development to allow seeding without leaving
   # unactioned jobs in the queue.
-  config.developer_response_grace_period = 0.seconds
+  config.developer_response_grace_period = nil
 
   # Disable rate limiting for local development.
   Rack::Attack.enabled = false

--- a/db/migrate/20211118171626_create_role_types.rb
+++ b/db/migrate/20211118171626_create_role_types.rb
@@ -1,4 +1,10 @@
 class CreateRoleTypes < ActiveRecord::Migration[7.0]
+  class Developer < ActiveRecord::Base
+  end
+
+  class RoleType < ActiveRecord::Base
+  end
+
   def change
     create_table :role_types do |t|
       t.belongs_to :developer, index: {unique: true}, foreign_key: true
@@ -11,7 +17,7 @@ class CreateRoleTypes < ActiveRecord::Migration[7.0]
     end
 
     Developer.find_each do |developer|
-      developer.create_role_type!
+      RoleType.create!(developer_id: developer.id)
     end
   end
 end

--- a/db/migrate/20220610180608_add_inbound_email_token_to_conversations.rb
+++ b/db/migrate/20220610180608_add_inbound_email_token_to_conversations.rb
@@ -1,4 +1,8 @@
 class AddInboundEmailTokenToConversations < ActiveRecord::Migration[7.0]
+  class Conversation < ActiveRecord::Base
+    has_secure_token :inbound_email_token
+  end
+
   def change
     add_column :conversations, :inbound_email_token, :string
     Conversation.find_each.map(&:regenerate_inbound_email_token)

--- a/db/migrate/20220610193544_add_authentication_token_to_users.rb
+++ b/db/migrate/20220610193544_add_authentication_token_to_users.rb
@@ -1,4 +1,8 @@
 class AddAuthenticationTokenToUsers < ActiveRecord::Migration[7.0]
+  class User < ActiveRecord::Base
+    has_secure_token :authentication_token
+  end
+
   def change
     add_column :users, :authentication_token, :string
     User.find_each.map(&:regenerate_authentication_token)

--- a/db/migrate/20221126042109_upgrade_to_pay_version6.rb
+++ b/db/migrate/20221126042109_upgrade_to_pay_version6.rb
@@ -12,7 +12,7 @@ class UpgradeToPayVersion6 < ActiveRecord::Migration[7.0]
     add_index :pay_subscriptions, :pause_starts_at
 
     Pay::Subscription.find_each do |pay_subscription|
-      pay_subscription.update(
+      pay_subscription.update!(
         metered: pay_subscription.data&.dig("metered"),
         pause_behavior: pay_subscription.data&.dig("pause_behavior"),
         pause_starts_at: pay_subscription.data&.dig("paddle_paused_from"),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,6 @@ end
 ActiveJob::Base.queue_adapter = :inline
 ActionMailer::Base.delivery_method = :test
 
-# Allow UpdateDeveloperResponseRateJob to run async.
-UpdateDeveloperResponseRateJob.queue_adapter = :async
-
 puts "Seeding #{Rails.env} database..."
 seed "admins"
 seed "developers"

--- a/test/jobs/update_developer_response_rate_job_test.rb
+++ b/test/jobs/update_developer_response_rate_job_test.rb
@@ -3,8 +3,6 @@ require "test_helper"
 class UpdateDeveloperResponseRateJobTest < ActiveJob::TestCase
   include BusinessesHelper
 
-  GRACE_PERIOD = UpdateDeveloperResponseRateJob::GRACE_PERIOD
-
   setup do
     @developer = developers(:one)
     create_answered_message_for(@developer)
@@ -56,7 +54,13 @@ class UpdateDeveloperResponseRateJobTest < ActiveJob::TestCase
   def start_conversation(developer, grace_period_expired)
     business = Business.create!(business_attributes)
     conversation = Conversation.create!(developer:, business:)
-    conversation.update!(created_at: GRACE_PERIOD.ago - 1.hour) if grace_period_expired
+
+    if grace_period_expired
+      grace_period = Rails.application.config.developer_response_grace_period
+      grace_period_start = grace_period.nil? ? Time.current : grace_period.ago
+      conversation.update!(created_at: grace_period_start - 1.hour)
+    end
+
     Message.create!(conversation:, sender: business, body: "First contact")
     conversation
   end


### PR DESCRIPTION
This PR fixes #826 - two issues preventing running the following command:
```
bin/rails db:drop db:create db:migrate db:seed
```

---

### Issue 1: Using ActiveRecord models in migrations

The rake task `db:seed` works without issue, but the combination `db:migrate db:seed` throws an error. This means there is some residual cached data available during the seeding process originating in the migrations.

There are multiple places in the migrations where ActiveRecord models are used directly. This is not a good practice for various reasons - and one of them is that after "touching" (using) a model, some column information is lazy loaded and cached. And if the corresponding database table is modified in the following migrations, the cached model doesn't know about it. That's why the method [`reset_column_information`](https://apidock.com/rails/ActiveRecord/Base/reset_column_information/class) exists.

I fixed it by defining and using temporary models directly in these migrations.

Commit: https://github.com/joemasilotti/railsdevs.com/commit/a799c2c6a30d24fc80ace62cd362ef6305a93885

---

### Issue 2: Trying to schedule future jobs with `inline` queue adapter

After fixing the previous issue, the task `db:migrate db:seed` produces the following error:
```
NotImplementedError: Use a queueing backend to enqueue jobs in the future.
railsdevs.com/app/models/concerns/messages/notifications.rb:36:in `update_developer_response_rate'
```

The `queue_adapter` is set to `inline` in the [`seeds.rb`](https://github.com/joemasilotti/railsdevs.com/blob/e2d1e6459fda6a53926041b68d0ca87f36a8c6a2/db/seeds.rb#L8-L13) file for all jobs except the `UpdateDeveloperResponseRateJob` - this one is set to `async` adapter. This job is scheduled during the seeding process using `set(wait:).perform_later`.

However, it seems that there are more jobs scheduled in the future with the mentioned one - related (possibly) to ActiveStorage, ActionMailer, Noticed etc. They use `inline` adapter, what is producing the `NotImplementedError`.

The issue occurs - once again - only when running both `db:migrate db:seed`. I don't know exactly why, it could be related to some loading magic in Rails.

The only problematic job (scheduled in the future during seeding) is `UpdateDeveloperResponseRateJob`. And in the development environment, the `wait` parameter is set to [`0.seconds`](https://github.com/joemasilotti/railsdevs.com/blob/e2d1e6459fda6a53926041b68d0ca87f36a8c6a2/config/environments/development.rb#L90) . So if the seeds are run only in development, we can easily fix it by setting the `wait` parameter to `nil` instead of `0.seconds`. This will call the `enqueue` method instead of the `enqueue_at` which is not implemented in the `inline` adapter ([related code](https://github.com/rails/rails/blob/2cef3ac45bd85e1642b1270ab4fa31629044c962/activejob/lib/active_job/queue_adapters/inline_adapter.rb#L14-L20)). 

Commit: https://github.com/joemasilotti/railsdevs.com/commit/87083be0a0329f2fa943dd837ba6b9b56e28d434