### PR TITLE
Populate Response Rate Badges during db seeding

### DIFF
--- a/db/seeds/conversations.rb
+++ b/db/seeds/conversations.rb
@@ -16,3 +16,7 @@ developer = User.find_by(email: "hired@example.com").developer
 business = User.find_by(email: "part-time@example.com").business
 conversation = Conversation.find_or_create_by!(developer:, business:)
 SeedsHelper.create_message!(conversation:, sender: business, body: "Looking for freelance work?", cold_message: true)
+
+# Populate response rate for developers
+developers = Developer.joins(:conversations).distinct
+developers.each{ UpdateDeveloperResponseRateJob.perform_now(_1) }


### PR DESCRIPTION
Run the UpdateDeveloperResponseRateJob after seeding Conversations so that a fresh development environment will display the Response Rate badges.

## Pull request checklist


- [x] My code contains tests covering the code I modified (Seeds checked via `bin/check`
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)
  (_minor change only_)

