### PR TITLE
Rename for param key for Admin::Businesses::HiringInvoiceRequestNotification

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -54,7 +54,7 @@ class AdminMailer < ApplicationMailer
     @notification = params[:record].to_notification
     recipient = params[:recipient]
 
-    @form = @notification.form
+    @form = @notification.hiring_invoice_request
     @business = @form.business
 
     mail(to: recipient.email, subject: @notification.title)

--- a/app/models/concerns/businesses/hiring_invoice_requests/notifications.rb
+++ b/app/models/concerns/businesses/hiring_invoice_requests/notifications.rb
@@ -9,7 +9,7 @@ module Businesses
       end
 
       def send_admin_notification
-        Admin::Businesses::HiringInvoiceRequestNotification.with(form: self).deliver_later(User.admin)
+        Admin::Businesses::HiringInvoiceRequestNotification.with(hiring_invoice_request: self).deliver_later(User.admin)
       end
     end
   end

--- a/app/notifications/admin/businesses/hiring_invoice_request_notification.rb
+++ b/app/notifications/admin/businesses/hiring_invoice_request_notification.rb
@@ -11,7 +11,7 @@ module Admin
       end
 
       def url
-        admin_businesses_hiring_invoice_requests_path(hiring_invoice_request)
+        admin_businesses_hiring_invoice_request_path(hiring_invoice_request)
       end
 
       def hiring_invoice_request

--- a/app/notifications/admin/businesses/hiring_invoice_request_notification.rb
+++ b/app/notifications/admin/businesses/hiring_invoice_request_notification.rb
@@ -4,18 +4,18 @@ module Admin
       deliver_by :database
       deliver_by :email, mailer: "AdminMailer", method: :businesses_hiring_invoice_request
 
-      param :form
+      param :hiring_invoice_request
 
       def title
-        t("notifications.admin.businesses.hiring_invoice_request_notification.title", business: form.business.name)
+        t("notifications.admin.businesses.hiring_invoice_request_notification.title", business: hiring_invoice_request.business.name)
       end
 
       def url
-        admin_businesses_hiring_invoice_requests_path(form)
+        admin_businesses_hiring_invoice_requests_path(hiring_invoice_request)
       end
 
-      def form
-        params[:form]
+      def hiring_invoice_request
+        params[:hiring_invoice_request]
       end
     end
   end

--- a/db/migrate/20230330000840_rename_hiring_invoice_request_notification_form_params.rb
+++ b/db/migrate/20230330000840_rename_hiring_invoice_request_notification_form_params.rb
@@ -1,10 +1,10 @@
 class RenameHiringInvoiceRequestNotificationFormParams < ActiveRecord::Migration[7.0]
   def up
-    migrate_notifications(old_param_name: 'form', new_param_name: 'hiring_invoice_request')
+    migrate_notifications(old_param_name: "form", new_param_name: "hiring_invoice_request")
   end
 
   def down
-    migrate_notifications(old_param_name: 'hiring_invoice_request', new_param_name: 'form')
+    migrate_notifications(old_param_name: "hiring_invoice_request", new_param_name: "form")
   end
 
   def migrate_notifications(old_param_name:, new_param_name:)
@@ -17,7 +17,7 @@ class RenameHiringInvoiceRequestNotificationFormParams < ActiveRecord::Migration
     execute(rename_sql)
 
     # 3. Symbolize new key with ActiveRecord
-    Notification.where(type: 'Admin::Businesses::HiringInvoiceRequestNotification').each do |notification|
+    Notification.where(type: "Admin::Businesses::HiringInvoiceRequestNotification").each do |notification|
       notification.update!(params: notification.params.transform_keys do |key|
         key == new_param_name ? new_param_name.to_sym : key
       end)

--- a/db/migrate/20230330000840_rename_hiring_invoice_request_notification_form_params.rb
+++ b/db/migrate/20230330000840_rename_hiring_invoice_request_notification_form_params.rb
@@ -1,0 +1,26 @@
+class RenameHiringInvoiceRequestNotificationFormParams < ActiveRecord::Migration[7.0]
+  def up
+    migrate_notifications(old_param_name: 'form', new_param_name: 'hiring_invoice_request')
+  end
+
+  def down
+    migrate_notifications(old_param_name: 'hiring_invoice_request', new_param_name: 'form')
+  end
+
+  def migrate_notifications(old_param_name:, new_param_name:)
+    # 2. Rename params key name
+    rename_sql = <<-SQL.squish
+      UPDATE notifications
+      SET params = jsonb_set( params, '{#{new_param_name}}', params->'#{old_param_name}')::jsonb - '#{old_param_name}'
+      WHERE params->'#{old_param_name}'->>'_aj_globalid' LIKE '%Businesses::HiringInvoiceRequest%';
+    SQL
+    execute(rename_sql)
+
+    # 3. Symbolize new key with ActiveRecord
+    Notification.where(type: 'Admin::Businesses::HiringInvoiceRequestNotification').each do |notification|
+      notification.update!(params: notification.params.transform_keys do |key|
+        key == new_param_name ? new_param_name.to_sym : key
+      end)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->

 This PR renames the param key for `Admin::Businesses::HiringInvoiceRequestNotification` from  `:form` to `:hiring_invoice_request` to match the model association

This also closes #848

<!-- Before you submit a pull request for review, please make sure... -->

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
