### PR TITLE
Add `developers.bumped_at`

### DIFF
--- a/app/components/developers/badges_component.html.erb
+++ b/app/components/developers/badges_component.html.erb
@@ -5,9 +5,9 @@
     </div>
   <% end %>
 
-  <% if recently_active? %>
+  <% if recently_added? %>
     <div class="mr-4 mb-2">
-      <%= render BadgeComponent.new(t(".recently_active"), color: "green") %>
+      <%= render BadgeComponent.new(t(".recently_added"), color: "green") %>
     </div>
   <% end %>
 

--- a/app/components/developers/badges_component.rb
+++ b/app/components/developers/badges_component.rb
@@ -1,7 +1,7 @@
 module Developers
   class BadgesComponent < ApplicationComponent
     delegate :featured?, to: :developer
-    delegate :recently_active?, to: :developer
+    delegate :recently_added?, to: :developer
     delegate :source_contributor?, to: :developer
     delegate :response_rate, to: :developer
 

--- a/app/controllers/admin/developers/source_contributors_controller.rb
+++ b/app/controllers/admin/developers/source_contributors_controller.rb
@@ -14,9 +14,7 @@ module Admin
       private
 
       def set_developer_source_contributor(source_contributor)
-        developer = Developer.find(params[:developer_id])
-        developer.source_contributor = source_contributor
-        developer.save!(touch: false)
+        Developer.find(params[:developer_id]).update!(source_contributor:)
       end
     end
   end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -90,6 +90,6 @@ class DevelopersController < ApplicationController
       location_attributes: [:city, :state, :country],
       role_type_attributes: RoleType::TYPES,
       role_level_attributes: RoleLevel::TYPES
-    )
+    ).merge(user_initiated: true)
   end
 end

--- a/app/models/concerns/developers/bumpable.rb
+++ b/app/models/concerns/developers/bumpable.rb
@@ -1,0 +1,45 @@
+module Developers
+  module Bumpable
+    extend ActiveSupport::Concern
+
+    included do
+      before_update :touch_bumped_at, if: :user_initiated
+    end
+
+    attr_accessor :user_initiated
+
+    private
+
+    SIGNIFICANT_ATTRIBUTES = %w[
+      name
+      hero
+      bio
+      search_status
+      website
+      github
+      linkedin
+      stack_overflow
+      twitter
+      mastodon
+      scheduling_link
+    ]
+
+    def touch_bumped_at
+      if significant_changes?
+        self.profile_updated_at = Time.current
+        self.bumped_at = Time.current unless recently_bumped?
+      end
+    end
+
+    def significant_changes?
+      (SIGNIFICANT_ATTRIBUTES & changes.keys).any? ||
+        role_type.changed? ||
+        role_level.changed? ||
+        location.changed?
+    end
+
+    def recently_bumped?
+      1.month.ago < bumped_at
+    end
+  end
+end

--- a/app/models/concerns/developers/bumpable.rb
+++ b/app/models/concerns/developers/bumpable.rb
@@ -6,7 +6,11 @@ module Developers
       before_update :touch_bumped_at, if: :user_initiated
     end
 
-    attr_accessor :user_initiated
+    attr_accessor :user_initiated, :specialties_changed
+
+    def specialty_changed(specialty)
+      self.specialties_changed = true
+    end
 
     private
 
@@ -25,7 +29,7 @@ module Developers
     ]
 
     def touch_bumped_at
-      if significant_changes?
+      if significant_changes? || specialties_changed
         self.profile_updated_at = Time.current
         self.bumped_at = Time.current unless recently_bumped?
       end

--- a/app/models/concerns/has_badges.rb
+++ b/app/models/concerns/has_badges.rb
@@ -2,19 +2,20 @@ module HasBadges
   extend ActiveSupport::Concern
 
   # TODO #758: Cache developer badges to a new model
-  BADGES = %i[high_response_rate source_contributor recently_active].freeze
+  BADGES = %i[high_response_rate source_contributor recently_added].freeze
 
-  RECENTLY_ACTIVE_LENGTH = 1.week
+  RECENTLY_ADDED_LENGTH = 1.week
+  RECENTLY_UPDATED_LENGTH = 1.week
   HIGH_RESPONSE_RATE_CUTTOFF = 90
 
   included do
-    scope :recently_active, -> { where("developers.updated_at >= ?", RECENTLY_ACTIVE_LENGTH.ago) }
+    scope :recently_added, -> { where("developers.created_at >= ?", RECENTLY_ADDED_LENGTH.ago) }
     scope :source_contributor, -> { where("source_contributor >= ?", true) }
     scope :high_response_rate, -> { where("response_rate >= ?", HIGH_RESPONSE_RATE_CUTTOFF) }
   end
 
-  def recently_active?
-    updated_at >= RECENTLY_ACTIVE_LENGTH.ago
+  def recently_added?
+    created_at >= RECENTLY_ADDED_LENGTH.ago
   end
 
   def high_response_rate?

--- a/app/models/concerns/has_specialties.rb
+++ b/app/models/concerns/has_specialties.rb
@@ -3,7 +3,8 @@ module HasSpecialties
 
   included do
     has_many :specialty_tags
-    has_many :specialties, -> { visible }, through: :specialty_tags, dependent: :destroy
+    has_many :specialties, -> { visible }, through: :specialty_tags, dependent: :destroy,
+      after_add: :specialty_changed, after_remove: :specialty_changed
 
     validates :specialties, length: {maximum: 5}
   end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,5 +1,6 @@
 class Developer < ApplicationRecord
   include Avatarable
+  include Developers::Bumpable
   include Developers::HasOnlineProfiles
   include Developers::Notifications
   include Developers::RichText

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -109,8 +109,8 @@ class DeveloperQuery
 
   def badges_filter_records
     badges.each do |badge|
-      if badge == :recently_active
-        @_records.merge!(Developer.recently_active)
+      if badge == :recently_added
+        @_records.merge!(Developer.recently_added)
       elsif badge == :source_contributor
         @_records.merge!(Developer.source_contributor)
       elsif badge == :high_response_rate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,9 +361,9 @@ en:
       source_contributor: Source contributor
       title: Admin
     badges_component:
-      featured: Featured developer
+      featured: Featured
       high_response_rate: High response rate
-      recently_active: Recently Active
+      recently_added: New profile
       source_contributor: Source Contributor
     celebration_package_requests:
       create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -256,7 +256,6 @@ fr:
       title: Admin
     badges_component:
       featured: En vedette
-      recently_active: Actif depuis peu
     count_component:
       cta: Réinitialiser les filtres
       title_html: Affichage de <span class='font-bold'>%{count}</span> sur <span class='font-bold'>%{total}</span>+ développeurs.

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -136,7 +136,6 @@ zh-CN:
       title: 管理员
     badges_component:
       featured: 出色开发者
-      recently_active: 最近活跃
       source_contributor: 来源贡献者
     count_component:
       cta: 重置过滤条件

--- a/db/migrate/20230404202658_add_developers_profile_updated_at_and_bumped_at.rb
+++ b/db/migrate/20230404202658_add_developers_profile_updated_at_and_bumped_at.rb
@@ -1,0 +1,9 @@
+class AddDevelopersProfileUpdatedAtAndBumpedAt < ActiveRecord::Migration[7.0]
+  def change
+    add_column :developers, :profile_updated_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    add_column :developers, :bumped_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+
+    Developer.update_all("profile_updated_at=updated_at")
+    Developer.update_all("bumped_at=updated_at")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_04_173436) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_04_202658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -146,6 +146,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_173436) do
     t.string "mastodon"
     t.boolean "product_announcement_notifications", default: true
     t.string "scheduling_link"
+    t.datetime "profile_updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "bumped_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["public_profile_key"], name: "index_developers_on_public_profile_key", unique: true
     t.index ["textsearchable_index_col"], name: "textsearchable_index", using: :gin
     t.index ["user_id"], name: "index_developers_on_user_id"

--- a/test/components/developers/badges_component_test.rb
+++ b/test/components/developers/badges_component_test.rb
@@ -6,11 +6,15 @@ module Developers
       @developer = developers(:one)
     end
 
-    test "renders recently active badge if the developer profile is active in last 7 days" do
-      @developer.updated_at = Date.current
+    test "renders recently added badge if the developer profile was added in the last 7 days" do
+      @developer.created_at = Date.current
       render_inline BadgesComponent.new(@developer)
       assert_selector("span[class~='bg-green-100']")
-      assert_text "Recently Active"
+      assert_text "New profile"
+
+      @developer.created_at = 2.weeks.ago
+      render_inline BadgesComponent.new(@developer)
+      refute_text "New profile"
     end
 
     test "renders feature badge if the developer profile is features" do

--- a/test/components/developers/card_component_test.rb
+++ b/test/components/developers/card_component_test.rb
@@ -49,18 +49,16 @@ module Developers
       assert_selector "a.border-l-4.border-blue-400"
     end
 
-    test "renders recently active badge if developer is active in last 7 days" do
+    test "renders recently added badge if developer is new in last 7 days" do
       @developer.update!(bio: "I am the first developer")
-      @developer.recently_active?
       render_inline(CardComponent.new(developer: @developer))
-      assert_text I18n.t("developers.badges_component.recently_active")
+      assert_text I18n.t("developers.badges_component.recently_added")
     end
 
-    test "doesn't render recently active badge if developer is active more than 7 days ago" do
-      @developer.update!(updated_at: 2.weeks.ago)
-      @developer.recently_active?
+    test "doesn't render recently added badge if developer was added more than 7 days ago" do
+      @developer.update!(created_at: 2.weeks.ago)
       render_inline(CardComponent.new(developer: @developer))
-      assert_no_text I18n.t("developers.card_component.recently_active")
+      assert_no_text I18n.t("developers.card_component.recently_added")
     end
 
     test "renders source_contributor badge if developer is a source contributor" do

--- a/test/components/developers/query_component_test.rb
+++ b/test/components/developers/query_component_test.rb
@@ -75,10 +75,10 @@ module Developers
 
     test "checks selected badges" do
       stub_feature_flag(:badge_filter, true) do
-        query = DeveloperQuery.new(badges: ["recently_active", "source_contributor"])
+        query = DeveloperQuery.new(badges: ["recently_added", "source_contributor"])
         render_inline QueryComponent.new(query:, user: @user, form_id: nil)
 
-        assert_selector build_input("badges[]", type: "checkbox", value: "recently_active", checked: true)
+        assert_selector build_input("badges[]", type: "checkbox", value: "recently_added", checked: true)
         assert_selector build_input("badges[]", type: "checkbox", value: "source_contributor", checked: true)
       end
     end

--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -6,6 +6,8 @@ one:
   search_status: actively_looking
   scheduling_link: https://example.com
   public_profile_key: abc123
+  profile_updated_at: <%= Time.current %>
+  bumped_at: <%= Time.current %>
 
 prospect:
   user: prospect_developer
@@ -13,3 +15,5 @@ prospect:
   hero: A prospect developer
   bio: I am prospect developer.
   search_status: open
+  profile_updated_at: <%= Time.current %>
+  bumped_at: <%= Time.current %>

--- a/test/integration/admin/developers/source_contributors_test.rb
+++ b/test/integration/admin/developers/source_contributors_test.rb
@@ -19,14 +19,4 @@ class Admin::Developers::SourceContributorsTest < ActionDispatch::IntegrationTes
 
     refute developer.reload.source_contributor?
   end
-
-  test "neither update the updated_at column" do
-    developer = developers(:one)
-    sign_in users(:admin)
-
-    assert_no_changes "developer.reload.updated_at" do
-      post admin_developer_source_contributors_path(developer)
-      delete admin_developer_source_contributors_path(developer)
-    end
-  end
 end

--- a/test/models/concerns/developers/bumpable_test.rb
+++ b/test/models/concerns/developers/bumpable_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+module Developers
+  class HasOnlineProfilesTest < ActiveSupport::TestCase
+    setup do
+      @developer = developers(:one)
+    end
+
+    test "touches profile_updated_at if significant changes were made" do
+      assert_changes "@developer.profile_updated_at" do
+        @developer.update!(bio: "New bio.", user_initiated: true)
+      end
+    end
+
+    test "touches profile_updated_at if significant association changes were made" do
+      assert_changes "@developer.profile_updated_at" do
+        @developer.update!(role_type_attributes: {part_time_contract: false}, user_initiated: true)
+      end
+
+      assert_changes "@developer.profile_updated_at" do
+        @developer.update!(role_level_attributes: {junior: false}, user_initiated: true)
+      end
+
+      assert_changes "@developer.profile_updated_at" do
+        @developer.update!(location_attributes: {country: "Canada"}, user_initiated: true)
+      end
+    end
+
+    test "doesn't touch profile_updated_at if no significant changes were made" do
+      assert_no_changes "@developer.profile_updated_at" do
+        @developer.update!(
+          profile_reminder_notifications: false,
+          featured_at: Time.current,
+          public_profile_key: "foo-bar",
+          response_rate: 100,
+          user_initiated: true
+        )
+      end
+    end
+
+    test "touches bumped_at if it was last changed over a month ago" do
+      @developer.bumped_at = 32.days.ago
+      @developer.save!(touch: false)
+
+      assert_changes "@developer.bumped_at" do
+        @developer.update!(bio: "New bio.", user_initiated: true)
+      end
+    end
+
+    test "doesn't touch bumped_at if it was changed within the last month" do
+      @developer.bumped_at = 27.days.ago
+      @developer.save!(touch: false)
+
+      assert_no_changes "@developer.bumped_at" do
+        @developer.update!(bio: "New bio.", user_initiated: true)
+      end
+    end
+
+    test "doesn't touch bumped_at if no significant changes were made" do
+      @developer.bumped_at = 27.days.ago
+      @developer.save!(touch: false)
+
+      assert_no_changes "@developer.bumped_at" do
+        @developer.update!(profile_reminder_notifications: false, user_initiated: true)
+      end
+    end
+
+    test "doesn't touch either if not initiated from a user action" do
+      @developer.bumped_at = 32.days.ago
+      @developer.save!(touch: false)
+
+      assert_no_changes "@developer.profile_updated_at" do
+        assert_no_changes "@developer.bumped_at" do
+          @developer.update!(bio: "New bio.", user_initiated: false)
+        end
+      end
+    end
+  end
+end

--- a/test/models/concerns/developers/bumpable_test.rb
+++ b/test/models/concerns/developers/bumpable_test.rb
@@ -24,6 +24,10 @@ module Developers
       assert_changes "@developer.profile_updated_at" do
         @developer.update!(location_attributes: {country: "Canada"}, user_initiated: true)
       end
+
+      assert_changes "@developer.profile_updated_at" do
+        @developer.update!(specialty_ids: [specialties(:one).id], user_initiated: true)
+      end
     end
 
     test "doesn't touch profile_updated_at if no significant changes were made" do

--- a/test/models/developer_test.rb
+++ b/test/models/developer_test.rb
@@ -181,13 +181,13 @@ class DeveloperTest < ActiveSupport::TestCase
     travel_back
   end
 
-  test "recently active developers within last one week" do
+  test "recently added developers within last one week" do
     @developer = developers(:one)
 
-    @developer.updated_at = 2.weeks.ago
-    refute @developer.recently_active?
+    @developer.created_at = 2.weeks.ago
+    refute @developer.recently_added?
 
-    @developer.updated_at = Date.current
-    assert @developer.recently_active?
+    @developer.created_at = Date.current
+    assert @developer.recently_added?
   end
 end

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -128,14 +128,14 @@ class DeveloperQueryTest < ActiveSupport::TestCase
     refute_includes records, blank
   end
 
-  test "filtering by recently active badge" do
-    recently_active_developer = create_developer
-    not_recently_active_developer = create_developer
-    not_recently_active_developer.update!(updated_at: 2.weeks.ago)
+  test "filtering by recently added badge" do
+    recently_added_developer = create_developer
+    not_recently_added_developer = create_developer
+    not_recently_added_developer.update!(created_at: 2.weeks.ago)
 
-    records = DeveloperQuery.new(badges: ["recently_active"]).records
-    assert_includes records, recently_active_developer
-    refute_includes records, not_recently_active_developer
+    records = DeveloperQuery.new(badges: ["recently_added"]).records
+    assert_includes records, recently_added_developer
+    refute_includes records, not_recently_added_developer
   end
 
   test "filtering by response rate badge" do
@@ -197,7 +197,7 @@ class DeveloperQueryTest < ActiveSupport::TestCase
       include_not_interested: true,
       search_query: "rails engineer",
       countries: ["United States"],
-      badges: [:recently_active]
+      badges: [:recently_added]
     }
     assert_equal DeveloperQuery.new(filters.dup).filters, filters
   end


### PR DESCRIPTION
This PR lays some groundwork for a change to the sorting algorithm.

It adds two new columns: `developers.profile_updated_at` and `developers.bumped_at`.

The former will be used to see how recent the profile was updated to know when to send the profile reminder emails. This means we can stop dancing around "touching" the profile when making changes outside of user-initiated flow.

The second is how devs will be sorted by default moving forward. Any public change to a profile will refresh the column if it was last updated more than 1 month ago.

In summary, a developer can "bump" their profile to the top of results once per month!

## Pull request checklist

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

## To-do

- [ ] Ensure `developers.profile_updated_at` is being used for reminder emails
- [ ] Rip out any remaining `touch: false` calls or dances around touching records
- [ ] (New PR) Start sorting developers by the new column
- [ ] Announcement email and maybe a dedicated page to how sorting works