### PR TITLE
Use postgresql@14 instead of deprecated postgresql

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 # Postgres
 brew "libpq" # M1 macs need libpq for pg gem
-brew "postgresql"
+brew "postgresql@14"
 
 # Redis
 brew "redis"


### PR DESCRIPTION
Currently when you run `brew bundle install` per the installation instructions, you see a deprecation warning for PostgreSQL's package:

```
Warning: Use postgresql@14 instead of deprecated postgresql
Warning: Use postgresql@14 instead of deprecated postgresql
```