### PR TITLE
Fix template path for pay mails

### DIFF
--- a/app/mailers/pay_mailer.rb
+++ b/app/mailers/pay_mailer.rb
@@ -1,4 +1,7 @@
 class PayMailer < Pay::UserMailer
+  # Use our custom templates if they exist, otherwise fall back to Pay
+  default template_path: %w[pay_mailer pay/user_mailer]
+
   def subscription_renewing
     @business = params[:pay_customer].owner.business
     @renewal_date = params[:date].to_date

--- a/test/mailers/previews/pay_mailer_preview.rb
+++ b/test/mailers/previews/pay_mailer_preview.rb
@@ -1,7 +1,9 @@
 class PayMailerPreview < ActionMailer::Preview
   def subscription_renewing
-    customer = Pay::Customer.first
-    renewal_date = 3.days.from_now
-    PayMailer.with(pay_customer: customer, date: renewal_date).subscription_renewing
+    PayMailer.with(
+      pay_customer: Pay::Customer.first,
+      pay_subscription: Pay::Subscription.first,
+      date: 3.days.from_now
+    ).subscription_renewing
   end
 end


### PR DESCRIPTION
Fixes a bug introduced in #860 - the new `PayMailer` inherits from `Pay::UserMailer` and overrides `subscription_renewing` email. However, Rails now looks for an email template for any other Pay email in `pay_mailer` path without a fallback to the original path `pay/user_mailer`, failing with `ActionView::MissingTemplate`.