### PR TITLE
Dismissible modal

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -4,9 +4,27 @@ export default class extends Controller {
   static targets = ["modal"]
   static values = {toggleTimeout: {type: Number, default: 1000}}
 
+  closeOnEsc(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  connect() {
+    document.addEventListener("keydown", this.closeOnEsc)
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.closeOnEsc)
+  }
+
   hideModal() {
     setTimeout(() => {
-      this.modalTarget.remove()
+      this.close()
     }, this.toggleTimeoutValue)
+  }
+
+  close() {
+    this.modalTarget.remove()
   }
 }

--- a/app/views/public_profiles/new.html.erb
+++ b/app/views/public_profiles/new.html.erb
@@ -2,7 +2,7 @@
   <%= tag.div data: {controller: "clipboard modal", clipboard_visibility_class: "hidden", clipboard_content_value: @developer.share_url, clipboard_html_content_value: @developer.share_url, modal_target: "modal"} do %>
     <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" data-action="click->modal#close"></div>
 
         <!-- This element is to trick the browser into centering the modal contents. -->
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>


### PR DESCRIPTION
I saw that the share modal wasn't dismissible by clicking the background or <kbd>esc</kbd>.

![Screenshot 2023-05-12 at 15 39 51](https://github.com/joemasilotti/railsdevs.com/assets/178448/7d9857bf-761d-41d7-88bc-f18e1b8a6cd9)

This PR fixes that.

## Pull request checklist

- [ ] ~My code contains tests covering the code I modified~
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~
