### PR TITLE
Recently updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### June
 
+* June 21 - Sort developers by recently updated, by default #871
 * June 7 - Render signed hiring agreement PDFs via Prawn #870
 
 ### April

--- a/app/components/developers/query_sort_button_component.html.erb
+++ b/app/components/developers/query_sort_button_component.html.erb
@@ -1,15 +1,11 @@
 <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden" id="sort" class="relative">
-  <span class="mr-2">
-    <%= render BadgeComponent.new("New!", color: :purple) %>
-  </span>
-
   <button data-accessibility-target="button" type="button" class="group inline-flex justify-center text-sm font-medium text-gray-700 hover:text-gray-900" data-action="toggle#toggle accessibility#toggleAriaExpanded" aria-expanded="false" aria-haspopup="true">
     <%= t(".sort.title") %>
     <%= inline_svg_tag "icons/solid/chevron_down.svg", class: "flex-shrink-0 -mr-1 ml-1 h-5 w-5 text-gray-400 group-hover:text-gray-500", aria_hidden: true %>
   </button>
 
   <div data-toggle-target="element" class="hidden origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-2xl bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-10" role="menu" aria-orientation="vertical" aria-labelledby="mobile-menu-button" tabindex="-1">
+    <%= render SortButtonComponent.new(title: t(".sort.freshest"), name: :sort, value: :freshest, active: sort == :freshest, form_id: form_id, scope: scope) %>
     <%= render SortButtonComponent.new(title: t(".sort.newest"), name: :sort, value: :newest, active: sort == :newest, form_id: form_id, scope: scope) %>
-    <%= render SortButtonComponent.new(title: t(".sort.recommended"), name: :sort, value: :recommended, active: sort == :recommended, form_id: form_id, scope: scope) %>
   </div>
 </div>

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -71,7 +71,7 @@ class Developer < ApplicationRecord
   scope :actively_looking_or_open, -> { where(search_status: [:actively_looking, :open, nil]) }
   scope :featured, -> { where("featured_at >= ?", FEATURE_LENGTH.ago).order(featured_at: :desc) }
   scope :newest_first, -> { order(created_at: :desc) }
-  scope :by_score, -> { order(search_score: :desc, created_at: :asc) }
+  scope :recently_updated_first, -> { order(updated_at: :desc) }
   scope :product_announcement_notifications, -> { where(product_announcement_notifications: true) }
   scope :profile_reminder_notifications, -> { where(profile_reminder_notifications: true) }
   scope :visible, -> { where.not(search_status: :invisible).or(where(search_status: nil)) }

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -41,7 +41,7 @@ class DeveloperQuery
   end
 
   def sort
-    @sort.to_s.downcase.to_sym == :recommended ? :recommended : :newest
+    @sort.to_s.downcase.to_sym == :newest ? :newest : :freshest
   end
 
   def countries
@@ -128,8 +128,8 @@ class DeveloperQuery
   end
 
   def sort_records
-    if sort == :recommended
-      @_records.merge!(Developer.by_score)
+    if sort == :freshest
+      @_records.merge!(Developer.recently_updated_first)
     else
       @_records.merge!(Developer.newest_first)
     end

--- a/app/views/developer_mailer/profile_reminder.html.erb
+++ b/app/views/developer_mailer/profile_reminder.html.erb
@@ -1,5 +1,8 @@
 <p>Hey <%= @developer.first_name %>,</p>
-<p>Joe, founder of <%= link_to "RailsDevs", root_url %> here. It looks like your developer profile hasn't been updated in a while. Is everything still accurate?</p>
-<p>If not, you can <%= link_to "update your profile", notification_url(@notification.record) %>. Or, if you've found a gig and are no longer looking let me know by replying to this email!</p>
+<p>Joe, founder of RailsDevs here. It looks like your developer profile hasn't been updated in a while.</p>
+<ul>
+  <li>Found a job? <%= link_to "Fill out this form", new_developers_celebration_package_request_url %> so I can send you some swag!</li>
+  <li>Still looking? <%= link_to "Update your profile", notification_url(@notification.record) %> to get bumped to the top of search results.</li>
+</ul>
 <%= render "shared/signature" %>
 <p><small><%= link_to "Update my email notification settings", edit_developer_url(@developer, anchor: "notifications") %>.</small></p>

--- a/app/views/developer_mailer/profile_reminder.text.erb
+++ b/app/views/developer_mailer/profile_reminder.text.erb
@@ -1,8 +1,12 @@
 Hey <%= @developer.first_name %>,
 
-Joe, founder of RailsDevs (<%= root_url %>) here. It looks like your developer profile hasn't been updated in a while. Is everything still accurate?
+Joe, founder of RailsDevs here. It looks like your developer profile hasn't been updated in a while.
 
-If not, you can update your profile (<%= notification_url(@notification.record) %>). Or, if you've found a gig and are no longer looking let me know by replying to this email!
+Found a job? Fill out this form so I can send you some swag!
+  <%= new_developers_celebration_package_request_url %>
+
+Still looking? Update your profile to get bumped to the top of search results.
+  <%= notification_url(@notification.record) %>
 
 <%= render "shared/signature" %>
 Update my email notification settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,8 +510,8 @@ en:
         title: Work preference
     query_sort_button_component:
       sort:
-        newest: Newest
-        recommended: Recommended
+        freshest: Recently updated
+        newest: Newest profiles
         title: Sort
     recommended_sort_banner:
       cta: Read more

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -24,24 +24,24 @@ class DevelopersTest < ActionDispatch::IntegrationTest
     assert_description_contains "looking for their"
   end
 
-  test "developers are sorted by newest first" do
-    create_developer(hero: "Oldest")
-    create_developer(hero: "Newest")
+  test "developers are sorted by when they updated their profile" do
+    create_developer(hero: "Recent Update").update!(updated_at: Date.today)
+    create_developer(hero: "Older Update").update!(updated_at: Date.yesterday)
 
     get developers_path
 
-    assert_select "button.font-medium[value=newest]"
-    assert response.body.index("Newest") < response.body.index("Oldest")
+    assert_select "button.font-medium[value=freshest]"
+    assert response.body.index("Recent Update") < response.body.index("Older Update")
   end
 
-  test "developers can be sorted by their search score" do
-    create_developer(hero: "Lower Score", search_score: 10)
-    create_developer(hero: "Higher Score", search_score: 20)
+  test "developers can be sorted by newest first" do
+    create_developer(hero: "Oldest")
+    create_developer(hero: "Newest")
 
-    get developers_path(sort: :recommended)
+    get developers_path(sort: :newest)
 
-    assert_select "button.font-medium[value=recommended]"
-    assert response.body.index("Higher Score") < response.body.index("Lower Score")
+    assert_select "button.font-medium[value=newest]"
+    assert response.body.index("Newest") < response.body.index("Oldest")
   end
 
   test "subscribers can filter developers by time zone" do

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -3,13 +3,12 @@ require "test_helper"
 class DeveloperQueryTest < ActiveSupport::TestCase
   include DevelopersHelper
 
-  test "sort defaults to :newest" do
-    assert_equal DeveloperQuery.new(sort: "newest").sort, :newest
+  test "sort defaults to :freshest" do
+    assert_equal DeveloperQuery.new.sort, :freshest
 
-    assert_equal DeveloperQuery.new(sort: "recommended").sort, :recommended
-    assert_equal DeveloperQuery.new(sort: "bogus").sort, :newest
-    assert_equal DeveloperQuery.new(sort: "").sort, :newest
-    assert_equal DeveloperQuery.new.sort, :newest
+    assert_equal DeveloperQuery.new(sort: "newest").sort, :newest
+    assert_equal DeveloperQuery.new(sort: "bogus").sort, :freshest
+    assert_equal DeveloperQuery.new(sort: "").sort, :freshest
   end
 
   test "default searching excludes developers not interested (or blank) search status" do

--- a/test/system/filters_test.rb
+++ b/test/system/filters_test.rb
@@ -1,10 +1,10 @@
 require "application_system_test_case"
 
 class FiltersTest < ApplicationSystemTestCase
-  test "recommended sort click adds sort param" do
+  test "freshest sort click adds sort param" do
     visit developers_path
-    sort_by "recommended"
-    assert_current_path(/sort=recommended/)
+    sort_by "freshest"
+    assert_current_path(/sort=freshest/)
   end
 
   test "developers newest sort click adds sort param" do
@@ -24,19 +24,19 @@ class FiltersTest < ApplicationSystemTestCase
 
   test "applying multiple filters to developers" do
     visit developers_path
-    sort_by "recommended"
+    sort_by "newest"
 
-    assert_current_path(/sort=recommended/)
+    assert_current_path(/sort=newest/)
 
     find(:css, "[name='include_not_interested']").set(true)
     find(:css, "input[type=submit]").click
 
-    assert_current_path(/sort=recommended/)
+    assert_current_path(/sort=newest/)
     assert_current_path(/include_not_interested=1/)
 
-    sort_by "newest"
+    sort_by "freshest"
 
-    assert_current_path(/sort=newest/)
+    assert_current_path(/sort=freshest/)
     assert_current_path(/include_not_interested=1/)
   end
 


### PR DESCRIPTION
Change the sorting algorithm to sort developers by when they _updated_ their profile, by default. Also, rip out the score based "recommendation" sorting until I can figure out if it actually works.

## Pull request checklist

- [x] My code contains tests covering the code I modified
- [x] I linted and tested the project with `bin/check`
- [x] I added significant changes and product updates to the [changelog](CHANGELOG.md)